### PR TITLE
Add links to side-channel attack resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository provides a home for:
 - **Documentation**\
   References to research that describes what causes side-channels and how they behave.
 
-  Docs are [here](docs/).
+  Docs are [here](docs/README.md).
 
 - **Mitigation development**\
   Ideas and prototypes for how to find and stop side-channel leaks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,60 @@
+# Documentation and resources
+
+We hope to keep this list of references up-to-date, improve taxonomy and classification, and expand the references to include a brief overview of the novel aspects of each attack.
+
+<!--
+
+What link to use for a given reference?
+
+Prefer the first of:
+- An arXiv.org abstract
+- A website with an obvious link to a paper
+- A link to the paper itself
+
+-->
+
+## Attacks
+
+[Meltdown](https://arxiv.org/abs/1801.01207)
+
+[Spectre](https://arxiv.org/abs/1801.01203)
+
+[LazyFP](https://arxiv.org/abs/1806.07480)
+
+[Foreshadow and Foreshadow-NG](https://foreshadowattack.eu/#paper)
+
+[Fallout](https://arxiv.org/abs/1905.12701) (also https://mdsattacks.com/)
+
+[Rogue in-flight data load (RIDL)](https://mdsattacks.com/)
+
+[ZombieLoad](https://zombieloadattack.com/)
+
+[Speculative buffer overflows](https://arxiv.org/abs/1807.03757)
+
+[NetSpectre](https://arxiv.org/abs/1807.10535)
+
+[Spoiler](https://arxiv.org/abs/1903.00446)
+
+[SMoTherSpectre](https://arxiv.org/abs/1903.01843)
+
+[ret2spec](https://arxiv.org/abs/1807.10364)
+
+[SWAPGS](https://businessresources.bitdefender.com/hubfs/noindex/Bitdefender-WhitePaper-SWAPGS.pdf) (from BitDefender)
+
+## Vendor resources
+
+[AMD product security developer resources](https://developer.amd.com/resources/speculative-execution/developer-resources/)
+
+[ARM guidance on speculative processor vulnerability](https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability)
+
+[Intel analysis of speculative execution side-channels](https://www.intel.com/content/www/us/en/architecture-and-technology/intel-analysis-of-speculative-execution-side-channels-paper.html)
+
+[Intel security software guidance](https://software.intel.com/security-software-guidance/software-guidance)
+
+[Intel security insights and deep dives](https://software.intel.com/security-software-guidance/insights)
+
+## Other analyses
+
+[_A systematic evaluation of transient execution attacks and defenses_](https://arxiv.org/abs/1811.05441)
+
+[Linux kernel documentation on hardware vulnerabilities](https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/index.html)


### PR DESCRIPTION
I want to expand this into a better reference, but it seems like there's
value in starting with a comprehensive list of links.