### PR TITLE
Fixing preprocessor directives format and a typo.

### DIFF
--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-#if defined(__i386__) or defined(__x86_64__) or defined(_M_X64) or \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
 #  ifdef _MSC_VER
 #    include <intrin.h>
@@ -39,7 +39,7 @@
 
 // Architecturally dependent full memory fence.
 static void MFence() {
-#if defined(__i386__) or defined(__x86_64__) or defined(_M_X64) or \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
   _mm_mfence();
 #elif defined(__aarch64__)
@@ -53,7 +53,7 @@ static void MFence() {
 
 // Architecturally dependent load memory fence.
 static void LFence() {
-#if defined(__i386__) or defined(__x86_64__) or defined(_M_X64) or \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
   _mm_lfence();
 #elif defined(__aarch64__)
@@ -68,7 +68,7 @@ static void LFence() {
 // Architecturally dependent CPU clock counter.
 static uint64_t RdTsc() {
   uint64_t result;
-#if defined(__i386__) or defined(__x86_64__) or defined(_M_X64) or \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
   result = __rdtsc();
 #elif defined(__aarch64__)
@@ -89,7 +89,7 @@ void ForceRead(const void *p) {
 
 // Architecturally dependent cache flush.
 void CLFlush(const void *memory) {
-#if defined(__i386__) or defined(__x86_64__) or defined(_M_X64) or \
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
   _mm_clflush(memory);
 #elif defined(__aarch64__)

--- a/demos/spectre_v1.cc
+++ b/demos/spectre_v1.cc
@@ -81,7 +81,7 @@ static char leak_byte(const char *data, size_t offset) {
 
       if (local_offset < *size_in_heap) {
         // This branch was trained to always be taken during speculative
-        // execution, so it's taken even on the tenth iteration, when the
+        // execution, so it's taken even on the 2048th iteration, when the
         // condition is false!
         ForceRead(&isolated_oracle[static_cast<size_t>(data[local_offset])]);
       }


### PR DESCRIPTION
Keyword or is not accepted by older version of MSVC (e.g. 19.00.23506).