### PR TITLE
Correct the LICENSE copyright statement.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Google LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I guess none of us actually read boilerplate license files. Oops.

(I am surprised this wasn't caught as part of the Ariane approvals process actually; doesn't the bot check these? I've made a note to investigate and report a bug on Tuesday.)

https://opensource.google.com/docs/releasing/contributions/ talks about what exactly to put in the copyright statement. I see at least one commit in a fork (adding support for a new platform), which I am actually really looking forward to reviewing, so we may eventually want to replace "Google" here with "The SafeSide authors" or the like. But, for now, since all the files use Google LLC, this should too.