### PR TITLE
Specify C++11 in code guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You generally only need to submit a CLA once, so if you've already submitted one
 
 ## Code style
 
-We use [Google's C++ style guide](https://google.github.io/styleguide/cppguide.html). Please run `clang-format` on your code before sending a pull request.
+We use C++11 with [Google's C++ style guide](https://google.github.io/styleguide/cppguide.html). Please run `clang-format` on your code before sending a pull request.
 
 ### Source code headers
 


### PR DESCRIPTION
The Google style guide has been updated to say "Currently, code should target C++17", which, while a cause for celebration, doesn't work so well with all the compilers we want to target, AIUI. So let's specify the language revision separately.