### PR TITLE
CMake config for Ret2Spec.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,18 @@ target_link_libraries(spectre_v1 safeside)
 add_executable(spectre_v4 demos/spectre_v4.cc)
 target_link_libraries(spectre_v4 safeside)
 
+if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+  # Ret2Spec -- speculative execution using return stack buffers
+  set(CMAKE_CXX_FLAGS "-fomit-frame-pointer")
+  add_executable(ret2spec demos/ret2spec.cc)
+  target_link_libraries(ret2spec safeside)
+endif()
+
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	
-	add_subdirectory(third_party/kmod)
+  add_subdirectory(third_party/kmod)
 
-	# Spectre V3 / Meltdown
-	add_executable(meltdown demos/meltdown.cc)
-	target_link_libraries(meltdown safeside)
-
+  # Spectre V3 / Meltdown
+  add_executable(meltdown demos/meltdown.cc)
+  target_link_libraries(meltdown safeside)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ target_link_libraries(spectre_v4 safeside)
 
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   # Ret2Spec -- speculative execution using return stack buffers
-  set(CMAKE_CXX_FLAGS "-fomit-frame-pointer")
   add_executable(ret2spec demos/ret2spec.cc)
+  target_compile_options(ret2spec PRIVATE -fomit-frame-pointer)
   target_link_libraries(ret2spec safeside)
 endif()
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -21,11 +21,8 @@ make
 # You need to load the kernel module before running this
 sudo ./meltdown
 
-
 ./spectre_v4
 
-# Ret2spec
-g++ -O2 -fomit-frame-pointer ret2spec.cc cache_sidechannel.cc instr.cc -o ret2spec
 ./ret2spec
 ```
 


### PR DESCRIPTION
Windows is not supported yet. MacOS requires explicit -fomit-frame-pointer specification.