### PR TITLE
Cosmetic improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
+set(CMAKE_BUILD_TYPE Release)
 
 project(safeside VERSION 0.1.0 LANGUAGES CXX)
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -4,14 +4,9 @@
 
 ```bash
 cd safeside
-
 mkdir build
-
 cd build
-
-// Debug builds may not work.
-cmake -DCMAKE_BUILD_TYPE=Release ../
-
+cmake ..
 make
 
 # Everything should be built now.

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -92,7 +92,7 @@ static void sigsegv(
     int /* signum */, siginfo_t * /* siginfo */, void *context) {
   // SIGSEGV signal handler.
   // Moves the instruction pointer to the "afterspeculation" label.
-  ucontext_t *ucontext = (ucontext_t *)context;
+  ucontext_t *ucontext = static_cast<ucontext_t *>(context);
 #ifdef __x86_64__
   ucontext->uc_mcontext.gregs[REG_RIP] =
       reinterpret_cast<greg_t>(afterspeculation);


### PR DESCRIPTION
Hardcode the CMAKE_BUILD_TYPE.
If someone really wants to create a debug build that fails on Ret2spec,
he should do it manually.
Avoid C-style casting in Meltdown source.