### PR TITLE
Improve architecture and compiler coverage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 language: cpp
 dist: xenial
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,20 @@ branches:
   only:
     - master
 language: cpp
-dist: xenial
+dist: bionic
 matrix:
   include:
-    - name: "clang (Linux)"
+    - name: "clang / Linux / x86_64"
       os: linux
       compiler: clang
-    - name: "gcc (Linux)"
+    - name: "gcc / Linux / x86_64, i386, aarch64, powerpc64"
       os: linux
       compiler: gcc
-    - name: "clang (macOS)"
+    - name: "clang / macOS / x86_64"
       os: osx
       compiler: clang
-    - name: "MSVC (Windows)"
+    - name: "MSVC / Windows / x64, Win32"
       os: windows
       # CMake picks up MSVC regardless of what compiler we specify here.
-install:
-  # Add Linux headers needed to build kernel module.
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      sudo apt-get install -y "linux-headers-$(uname -r)";
-    fi
 script:
-  # It would be a bit nicer to use `cmake -B build .`, but `-B` isn't
-  # supported on older CMake.
-  - mkdir build
-  - cd build
-  - cmake ..
-  # Invoke build in platform+generator agnostic way
-  - cmake --build .
+  - ./ci/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,4 @@ cmake_minimum_required(VERSION 3.5.1)
 project(safeside VERSION 0.1.0 LANGUAGES C CXX)
 
 add_subdirectory(demos)
+add_subdirectory(third_party/kmod)

--- a/ci/build
+++ b/ci/build
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+set -o xtrace
+
+# Calls CMake to generate build files and then run the build.
+# Usage:
+#   generate_and_build <output directory> [<other generate args> ...]
+generate_and_build() {
+  local folder_name=$1
+  shift
+
+  mkdir "${folder_name}"
+  (cd "${folder_name}"; cmake "$@" ..)
+  cmake --build "${folder_name}"
+}
+
+# Choose what to do based on OS and compiler.
+case "${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}" in
+  linux_clang)
+    sudo apt install "linux-headers-$(uname -r)"
+
+    generate_and_build build
+    ;;
+
+  osx_clang)
+    generate_and_build build
+    ;;
+
+  windows_*)
+    generate_and_build build-x64 -A x64
+    generate_and_build build-win32 -A Win32
+    ;;
+
+  linux_gcc)
+    # Need this `apt update` for the install to succeed. Without it, the
+    # Travis worker only has lists for the ${distro}-security repository.
+    sudo apt update
+    sudo apt install \
+        "linux-headers-$(uname -r)" \
+        g++-i686-linux-gnu \
+        g++-aarch64-linux-gnu \
+        g++-powerpc64-linux-gnu
+
+    generate_and_build build-x86_64
+
+    generate_and_build build-i686 \
+        -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/i686-linux-gnu.cmake
+
+    generate_and_build build-aarch64 \
+        -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/aarch64-linux-gnu.cmake
+
+    generate_and_build build-powerpc64 \
+        -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/powerpc64-linux-gnu.cmake
+    ;;
+esac

--- a/ci/toolchains/aarch64-linux-gnu.cmake
+++ b/ci/toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,6 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)

--- a/ci/toolchains/i686-linux-gnu.cmake
+++ b/ci/toolchains/i686-linux-gnu.cmake
@@ -1,0 +1,6 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+set(CMAKE_SYSTEM_PROCESSOR i686)
+
+set(CMAKE_C_COMPILER i686-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER i686-linux-gnu-g++)

--- a/ci/toolchains/powerpc64-linux-gnu.cmake
+++ b/ci/toolchains/powerpc64-linux-gnu.cmake
@@ -1,0 +1,6 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+set(CMAKE_SYSTEM_PROCESSOR powerpc64)
+
+set(CMAKE_C_COMPILER powerpc64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER powerpc64-linux-gnu-g++)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -11,6 +11,13 @@ add_compile_options(-O1)
 # debug build settings, but it's incompatible with optimizations.
 string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
 
+# When targeting x86, we need to opt in to SSE2 instructions like
+# clflush, mfence, lfence.
+if((${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)$") AND
+   (${CMAKE_C_COMPILER_ID} MATCHES "^(Clang)|(GNU)$"))
+  add_compile_options(-msse2)
+endif()
+
 # Support library
 add_library(safeside cache_sidechannel.cc instr.cc)
 
@@ -26,14 +33,16 @@ target_link_libraries(spectre_v1_indirect_jumps safeside)
 add_executable(spectre_v4 spectre_v4.cc)
 target_link_libraries(spectre_v4 safeside)
 
-if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)|(Darwin)$") AND
+   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)|(x86_64)|(aarch64)$"))
   # Ret2Spec -- speculative execution using return stack buffers
   add_executable(ret2spec ret2spec.cc)
   target_compile_options(ret2spec PRIVATE -fomit-frame-pointer)
   target_link_libraries(ret2spec safeside)
 endif()
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$") AND
+   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)|(x86_64)|(ppc64)$"))
   # Spectre V3 / Meltdown
   add_executable(meltdown meltdown.cc)
   target_link_libraries(meltdown safeside)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -34,8 +34,6 @@ if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  add_subdirectory(../third_party/kmod kmod)
-
   # Spectre V3 / Meltdown
   add_executable(meltdown meltdown.cc)
   target_link_libraries(meltdown safeside)

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -115,7 +115,7 @@ uint64_t ReadLatency(const void *memory) {
   return result;
 }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__powerpc__)
 __attribute__((noinline))
 void UnwindStackAndSlowlyReturnTo(const void *address) {
 #if defined(__x86_64__) || defined(_M_X64)

--- a/third_party/kmod/CMakeLists.txt
+++ b/third_party/kmod/CMakeLists.txt
@@ -1,13 +1,30 @@
 # Builds the Meltdown kernel module.
 
-set(MODULE_NAME kernel_data)
+# Check if we should skip building the module.
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  message(STATUS "Skipping Meltdown kernel module on non-Linux OS")
+  return()
+elseif(${CMAKE_CROSSCOMPILING})
+  message(STATUS "Skipping Meltdown kernel module in cross-compile build")
+  return()
+endif()
 
 # Determine what kernel source tree we'll use to build the module.
-# CMAKE_SYSTEM_VERSION defaults to CMAKE_HOST_SYSTEM_VERSION, which is
-# documented to use `uname -r` on systems (like Linux) that support `uname`.
+# CMAKE_HOST_SYSTEM_VERSION uses `uname -r` on Linux.
 # https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_VERSION.html
-set(KERNEL_SRC "/lib/modules/${CMAKE_SYSTEM_VERSION}/build" )
-message(STATUS "Kernel build directory: ${KERNEL_SRC}")
+set(KERNEL_SRC "/lib/modules/${CMAKE_HOST_SYSTEM_VERSION}/build")
+
+if(EXISTS "${KERNEL_SRC}")
+  message(STATUS "Kernel build directory: ${KERNEL_SRC}")
+else()
+  message(FATAL_ERROR
+      " Can't find headers to build Meltdown kernel module.\n"
+      " Try:\n"
+      "     sudo apt install linux-headers-${CMAKE_HOST_SYSTEM_VERSION}"
+  )
+endif()
+
+set(MODULE_NAME kernel_data)
 
 # Move the inputs into a directory in the output first. Kbuild seems to use
 # KBUILD_EXTMOD to set both the source of the out-of-tree kernel module to


### PR DESCRIPTION
Here's the new build matrix:

![image](https://user-images.githubusercontent.com/1052311/66244231-5cff8300-e6bc-11e9-8213-54d372c4f344.png)

([link](https://travis-ci.org/google/safeside/builds/593764690))

To keep results from CI relatively quick, I purposefully only added the new builds for `gcc` -- hopefully bugs that occur on Clang (but not GCC) and on, say, `aarch64` (but not `x86_64`) will be very rare.

See individual commits for more details.