### PR TITLE
Replacing powerpc64 with powerpc64le.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - name: "clang / Linux / x86_64"
       os: linux
       compiler: clang
-    - name: "gcc / Linux / x86_64, i386, aarch64, powerpc64"
+    - name: "gcc / Linux / x86_64, i386, aarch64, powerpc64le"
       os: linux
       compiler: gcc
     - name: "clang / macOS / x86_64"

--- a/ci/build
+++ b/ci/build
@@ -40,7 +40,7 @@ case "${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}" in
         "linux-headers-$(uname -r)" \
         g++-i686-linux-gnu \
         g++-aarch64-linux-gnu \
-        g++-powerpc64-linux-gnu
+        g++-powerpc64le-linux-gnu
 
     generate_and_build build-x86_64
 
@@ -50,7 +50,7 @@ case "${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}" in
     generate_and_build build-aarch64 \
         -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/aarch64-linux-gnu.cmake
 
-    generate_and_build build-powerpc64 \
-        -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/powerpc64-linux-gnu.cmake
+    generate_and_build build-powerpc64le \
+        -DCMAKE_TOOLCHAIN_FILE=ci/toolchains/powerpc64le-linux-gnu.cmake
     ;;
 esac

--- a/ci/toolchains/powerpc64-linux-gnu.cmake
+++ b/ci/toolchains/powerpc64-linux-gnu.cmake
@@ -1,6 +1,0 @@
-set(CMAKE_SYSTEM_NAME Linux)
-
-set(CMAKE_SYSTEM_PROCESSOR powerpc64)
-
-set(CMAKE_C_COMPILER powerpc64-linux-gnu-gcc)
-set(CMAKE_CXX_COMPILER powerpc64-linux-gnu-g++)

--- a/ci/toolchains/powerpc64le-linux-gnu.cmake
+++ b/ci/toolchains/powerpc64le-linux-gnu.cmake
@@ -1,0 +1,6 @@
+set(CMAKE_SYSTEM_NAME Linux)
+
+set(CMAKE_SYSTEM_PROCESSOR powerpc64le)
+
+set(CMAKE_C_COMPILER powerpc64le-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER powerpc64le-linux-gnu-g++)


### PR DESCRIPTION
To make it compatible with the PowerPC workstation that we support.