### PR TITLE
Avoid SIGSEGV on ret2spec with -O0.

### DIFF
--- a/demos/instr.h
+++ b/demos/instr.h
@@ -26,9 +26,14 @@ void CLFlush(const void *memory);
 uint64_t ReadLatency(const void *memory);
 
 #ifdef __GNUC__
-// Unwinds the stack until the given pointer, flushes the stack pointer and
-// returns.
-void UnwindStackAndSlowlyReturnTo(const void *address);
+// Unwinds the stack until the given pointer (minus one byte), flushes the
+// stack pointer and returns. We use the pointer minus one instead of pointer
+// because of cases when the function argument is stored on the stack that
+// we want to unroll.
+void UnwindStackAndSlowlyReturnTo(const char *address);
+
+// Detects in runtime whether the compilation was optimized.
+bool OptimizedCompilation();
 
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86) || defined(__powerpc__)

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -53,9 +53,10 @@ __attribute__((noinline))
 static void speculation() {
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
-  const void *return_address = afterspeculation;
+  const char *return_address = afterspeculation + 1;
 #elif defined(__aarch64__)
-  const void *return_address = reinterpret_cast<const void *>(return_handler);
+  const char *return_address =
+      reinterpret_cast<const char *>(return_handler) + 1;
 #else
 #  error Unsupported CPU.
 #endif
@@ -119,6 +120,15 @@ static char leak_byte() {
 }
 
 int main() {
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
+  if (!OptimizedCompilation()) {
+    std::cerr << "Unoptimized compilation. "
+              << "Compile the example with -O2 -fomit-frame-pointer."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+#endif
   std::cout << "Leaking the string: ";
   std::cout.flush();
   for (size_t i = 0; i < strlen(private_data); ++i) {


### PR DESCRIPTION
Fixing https://github.com/google/safeside/issues/26
Removing ISB from load barrier and stack unwinding. It's not necessary for Rasberry Pi and it makes the ret2spec break on Cavium.