### PR TITLE
Recursive ret2spec bugfix.

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -19,7 +19,7 @@ if((${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)$") AND
 endif()
 
 # Support library
-add_library(safeside cache_sidechannel.cc instr.cc)
+add_library(safeside cache_sidechannel.cc instr.cc utils.cc)
 
 # Spectre V1 -- bounds check bypass
 add_executable(spectre_v1 spectre_v1.cc)

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "cache_sidechannel.h"
-
 #include <list>
 #include <vector>
 
+#include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Returns the indices of the biggest and second-biggest values in the range.
 template <typename RangeT>

--- a/demos/eret_hvc_smc_wrapper.cc
+++ b/demos/eret_hvc_smc_wrapper.cc
@@ -56,6 +56,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Private data to be leaked.
 const char *private_data = "It's a s3kr3t!!!";

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -17,6 +17,7 @@
 // File containing architecturally dependent features implemented in inline
 // assembler.
 #include "instr.h"
+#include "utils.h"
 
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
@@ -81,12 +82,6 @@ static uint64_t RdTsc() {
 #  error Unsupported CPU.
 #endif
   return result;
-}
-
-// Forces a memory read of the byte at address p. This will result in the byte
-// being loaded into cache.
-void ForceRead(const void *p) {
-  (void)*reinterpret_cast<const volatile char *>(p);
 }
 
 // Architecturally dependent cache flush.

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -23,9 +23,6 @@ constexpr uint32_t kPageSizeBytes = 65536;
 constexpr uint32_t kPageSizeBytes = 4096;
 #endif
 
-// Forced memory load.
-void ForceRead(const void *p);
-
 // Flushing cacheline containing given address.
 void CLFlush(const void *memory);
 

--- a/demos/l1tf.cc
+++ b/demos/l1tf.cc
@@ -34,6 +34,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 const char *private_data = "It's a s3kr3t!!!";
 char *private_page = nullptr;

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -19,8 +19,6 @@
 #include <fstream>
 #include <iostream>
 
-// TODO(asteinha): Windows, MacOS and vulnerable ARM support.
-
 #ifndef __linux__
 #  error Unsupported OS. Linux required.
 #endif
@@ -33,6 +31,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Objective: given some control over accesses to the *non-secret* string
 // "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" that is

--- a/demos/meltdown_ac.cc
+++ b/demos/meltdown_ac.cc
@@ -48,6 +48,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 const char *public_data = "Hello, world!";
 const char *private_data = "It's a s3kr3t!!!";

--- a/demos/meltdown_ss.cc
+++ b/demos/meltdown_ss.cc
@@ -47,6 +47,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Have one dummy character on the beginning of the private data. Segment limit
 // zero means that exactly one address is accessible. We want to access only

--- a/demos/meltdown_ud.cc
+++ b/demos/meltdown_ud.cc
@@ -31,6 +31,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 const char *public_data = "Hello, world!";
 const char *private_data = "It's a s3kr3t!!!";

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -20,6 +20,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // TODO(asteinha) Implement support for MSVC and Windows.
 // TODO(asteinha) Investigate the exploitability of PowerPC.

--- a/demos/ret2spec_cyclic.cc
+++ b/demos/ret2spec_cyclic.cc
@@ -95,6 +95,7 @@ static bool ReturnsTrue(int counter) {
        i += kCacheLineSize) {
     CLFlush(&stack_mark + i);
   }
+  CLFlush(stack_mark_pointers.back());
   return true;
 }
 

--- a/demos/ret2spec_cyclic.cc
+++ b/demos/ret2spec_cyclic.cc
@@ -36,6 +36,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 const char *private_data = "It's a s3kr3t!!!";
 

--- a/demos/ret2spec_cyclic.cc
+++ b/demos/ret2spec_cyclic.cc
@@ -92,11 +92,7 @@ static bool ReturnsTrue(int counter) {
   // own stack mark and the next one. Somewhere there must be also the return
   // address.
   stack_mark_pointers.pop_back();
-  for (int i = 0; i < (stack_mark_pointers.back() - &stack_mark);
-       i += kCacheLineSize) {
-    CLFlush(&stack_mark + i);
-  }
-  CLFlush(stack_mark_pointers.back());
+  FlushFromCache(&stack_mark, stack_mark_pointers.back());
   return true;
 }
 

--- a/demos/spectre_v1.cc
+++ b/demos/spectre_v1.cc
@@ -20,6 +20,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Objective: given some control over accesses to the *non-secret* string
 // "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" without

--- a/demos/spectre_v1_indirect_jumps.cc
+++ b/demos/spectre_v1_indirect_jumps.cc
@@ -20,6 +20,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Objective: given some control over accesses to the *non-secret* string
 // "xxxxxxxxxxxxxx", construct a program that obtains "It's a s3kr3t!!!" without
@@ -123,9 +124,7 @@ static char LeakByte(size_t offset) {
       // We make sure to flush whole accessor object in case it is
       // hypothetically on multiple cache-lines.
       const char *accessor_bytes = reinterpret_cast<const char*>(accessor);
-      for (size_t j = 0; j < object_size_in_bytes; j += kCacheLineSize) {
-        CLFlush(accessor_bytes + j);
-      }
+      FlushFromCache(accessor_bytes, accessor_bytes + object_size_in_bytes);
 
       // Speculative fetch at the offset. Architecturally it fetches
       // always from the public_data, though speculatively it fetches the

--- a/demos/spectre_v4.cc
+++ b/demos/spectre_v4.cc
@@ -22,6 +22,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 // Objective: given some control over accesses to the *non-secret* string
 // "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" without

--- a/demos/speculation_over_syscall.cc
+++ b/demos/speculation_over_syscall.cc
@@ -33,6 +33,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "utils.h"
 
 const char *public_data = "Hello, world!";
 const char *private_data = "It's a s3kr3t!!!";

--- a/demos/utils.cc
+++ b/demos/utils.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+
+#include "instr.h"
+#include "utils.h"
+
+constexpr size_t kCacheLineSize = 64;
+
+// Forces a memory read of the byte at address p. This will result in the byte
+// being loaded into cache.
+void ForceRead(const void *p) {
+  (void)*reinterpret_cast<const volatile char *>(p);
+}
+
+// Flush a memory interval from cache.
+void FlushFromCache(const char *start, const char *end) {
+  // Start on the first byte and continue in kCacheLineSize steps.
+  for (const char *ptr = start; ptr < end; ptr += kCacheLineSize) {
+    CLFlush(ptr);
+  }
+  // Flush explicitly the last byte.
+  CLFlush(end - 1);
+}

--- a/demos/utils.cc
+++ b/demos/utils.cc
@@ -21,13 +21,15 @@
 
 constexpr size_t kCacheLineSize = 64;
 
-// Forces a memory read of the byte at address p. This will result in the byte
-// being loaded into cache.
+// Forced memory load. Used during both real and speculative execution to create
+// a microarchitectural side effect in the cache. Also used for latency
+// measurement in the FLUSH+RELOAD technique.
 void ForceRead(const void *p) {
   (void)*reinterpret_cast<const volatile char *>(p);
 }
 
-// Flush a memory interval from cache.
+// Flush a memory interval from cache. Used to induce speculative execution on
+// flushed values until they are fetched back to the cache.
 void FlushFromCache(const char *start, const char *end) {
   // Start on the first byte and continue in kCacheLineSize steps.
   for (const char *ptr = start; ptr < end; ptr += kCacheLineSize) {

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -15,7 +15,8 @@
  */
 
 // Forced memory load. Used during both real and speculative execution to create
-// a microarchitectural side effect in the cache.
+// a microarchitectural side effect in the cache. Also used for latency
+// measurement in the FLUSH+RELOAD technique.
 void ForceRead(const void *p);
 
 // Flush a memory interval from cache. Used to induce speculative execution on

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Forced memory load.
+void ForceRead(const void *p);
+
+// Flush a memory interval from cache.
+void FlushFromCache(const char *start, const char *end);

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-// Forced memory load.
+// Forced memory load. Used during speculative execution to create a
+// microarchitectural side effect in the cache.
 void ForceRead(const void *p);
 
-// Flush a memory interval from cache.
+// Flush a memory interval from cache. Used to induce speculative execution on
+// flushed values until they are fetched back to the cache.
 void FlushFromCache(const char *start, const char *end);

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-// Forced memory load. Used during speculative execution to create a
-// microarchitectural side effect in the cache.
+// Forced memory load. Used during both real and speculative execution to create
+// a microarchitectural side effect in the cache.
 void ForceRead(const void *p);
 
 // Flush a memory interval from cache. Used to induce speculative execution on


### PR DESCRIPTION
We have to flush the whole stack frame which didn't happen when it was on multiple cache lines.