### PR TITLE
Extension of memory and speculation barrier.

### DIFF
--- a/demos/instr.h
+++ b/demos/instr.h
@@ -49,11 +49,11 @@ uint64_t ReadLatency(const void *memory);
 #ifdef _MSC_VER
 __forceinline
 #elif defined(__GNUC__)
-__attribute__((always_inline))
+__attribute__((always_inline)) inline
 #else
 #  error Unsupported compiler.
 #endif
-inline void MemoryAndSpeculationBarrier() {
+void MemoryAndSpeculationBarrier() {
 #if defined(__i386__) || defined(__x86_64__)
 #  ifdef _MSC_VER
   int cpuinfo [4];

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -57,7 +57,7 @@ inline void MemoryAndSpeculationBarrier() {
 #if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
     defined(_M_IX86)
 #  ifdef _MSC_VER
-  int cpuinfo [4];
+  int cpuinfo[4];
   __cpuid(cpuinfo, 0);
 #  elif defined(__GNUC__)
   int a, b, c, d;

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -49,12 +49,13 @@ uint64_t ReadLatency(const void *memory);
 #ifdef _MSC_VER
 __forceinline
 #elif defined(__GNUC__)
-__attribute__((always_inline)) inline
+__attribute__((always_inline))
 #else
 #  error Unsupported compiler.
 #endif
-void MemoryAndSpeculationBarrier() {
-#if defined(__i386__) || defined(__x86_64__)
+inline void MemoryAndSpeculationBarrier() {
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
 #  ifdef _MSC_VER
   int cpuinfo [4];
   __cpuid(cpuinfo, 0);

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -51,7 +51,7 @@ SAFESIDE_ALWAYS_INLINE
 inline void MemoryAndSpeculationBarrier() {
 #if SAFESIDE_X64 || SAFESIDE_IA32
 #  if SAFESIDE_MSVC
-  int cpuinfo [4];
+  int cpuinfo[4];
   __cpuid(cpuinfo, 0);
 #  elif SAFESIDE_GNUC
   int a, b, c, d;

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -16,12 +16,15 @@
 
 #include <cstdint>
 
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_X64) || \
+    defined(_M_IX86)
 #ifdef _MSC_VER
 #include <intrin.h>
 #elif defined(__GNUC__)
 #include <cpuid.h>
 #else
 #  error Unsupported compiler.
+#endif
 #endif
 
 // Page size.


### PR DESCRIPTION
CPUID uses intrinsics in order to support 64-bit Windows.
ARM version of memory and speculation barrier.