### PR TITLE
Make Meltdown and Foreshadow build on PowerPC in Travis CI.

### DIFF
--- a/ci/toolchains/powerpc64le-linux-gnu.cmake
+++ b/ci/toolchains/powerpc64le-linux-gnu.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_SYSTEM_NAME Linux)
 
-set(CMAKE_SYSTEM_PROCESSOR powerpc64le)
+set(CMAKE_SYSTEM_PROCESSOR powerpc64)
 
 set(CMAKE_C_COMPILER powerpc64le-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER powerpc64le-linux-gnu-g++)

--- a/ci/toolchains/powerpc64le-linux-gnu.cmake
+++ b/ci/toolchains/powerpc64le-linux-gnu.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_SYSTEM_NAME Linux)
 
-set(CMAKE_SYSTEM_PROCESSOR powerpc64)
+set(CMAKE_SYSTEM_PROCESSOR ppc64le)
 
 set(CMAKE_C_COMPILER powerpc64le-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER powerpc64le-linux-gnu-g++)


### PR DESCRIPTION
Testing why Travis does not build Meltdown and Foreshadow with PowerPC.