### PR TITLE
Avoid uninitialized memory in Meltdown-SS.

### DIFF
--- a/demos/meltdown_ss.cc
+++ b/demos/meltdown_ss.cc
@@ -58,6 +58,7 @@ const char *public_data = "Hello, world!";
 static void setup_segment(int index, const char *base, bool present) {
   // See: Intel SDM volume 3a "3.4.5 Segment Descriptors".
   struct user_desc table_entry;
+  memset(&table_entry, 0, sizeof(struct user_desc));
   table_entry.entry_number = index;
   table_entry.base_addr = reinterpret_cast<unsigned int>(base);
   // No size limit for a present segment, one byte for a non-present segment.
@@ -74,8 +75,6 @@ static void setup_segment(int index, const char *base, bool present) {
   table_entry.limit_in_pages = 0;
   // True iff present is false.
   table_entry.seg_not_present = !present;
-  // Useable entry.
-  table_entry.useable = 1;
   int result = syscall(__NR_modify_ldt, 1, &table_entry,
                        sizeof(struct user_desc));
   if (result != 0) {


### PR DESCRIPTION
And do not use the useable bit if there is no implementation need to do that.
It's a bit that is for the system or user disposal and is ignored (but preserved) by the CPU.