### PR TITLE
Factoring out public and private data.

### DIFF
--- a/demos/eret_hvc_smc_wrapper.cc
+++ b/demos/eret_hvc_smc_wrapper.cc
@@ -58,10 +58,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-// Private data to be leaked.
-const char *private_data = "It's a s3kr3t!!!";
 
 // Userspace wrapper of the eret_hvc_smc kernel module.
 // Writes userspace addresses into a SYSFS file while the kernel handler

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -185,13 +185,15 @@ inline void BoundsCheck(const char *str, size_t offset) {
 // Reads an offset from the FS segment.
 // Must be inlined because the fault occurs inside and the stack pointer would
 // be shifted.
+// We fetch offset + 1 from the segment base, because the base is shifted one
+// byte below to bypass 1-byte minimal segment size.
 SAFESIDE_ALWAYS_INLINE
 inline unsigned int ReadUsingFS(unsigned int offset) {
   unsigned int result;
 
   asm volatile(
       "movzbl %%fs:(, %1, 1), %0\n"
-      :"=r"(result):"r"(offset):"memory");
+      :"=r"(result):"r"(offset + 1):"memory");
 
   return result;
 }
@@ -199,13 +201,15 @@ inline unsigned int ReadUsingFS(unsigned int offset) {
 // Reads an offset from the ES segment.
 // Must be inlined because the fault occurs inside and the stack pointer would
 // be shifted.
+// We fetch offset + 1 from the segment base, because the base is shifted one
+// byte below to bypass 1-byte minimal segment size.
 SAFESIDE_ALWAYS_INLINE
 inline unsigned int ReadUsingES(unsigned int offset) {
   unsigned int result;
 
   asm volatile(
       "movzbl %%es:(, %1, 1), %0\n"
-      :"=r"(result):"r"(offset):"memory");
+      :"=r"(result):"r"(offset + 1):"memory");
 
   return result;
 }

--- a/demos/l1tf.cc
+++ b/demos/l1tf.cc
@@ -36,9 +36,9 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
 
-const char *private_data = "It's a s3kr3t!!!";
 char *private_page = nullptr;
 
 /**

--- a/demos/local_content.h
+++ b/demos/local_content.h
@@ -18,6 +18,14 @@
 
 #include "compiler_specifics.h"
 
+// Generic strings used across examples. The public_data is intended to be
+// accessed in the C++ execution model. The content of the private_data is
+// intended to be leaked outside of the C++ execution model using sidechannels.
+// Concrete sidechannel is dependent on the concrete vulnerability that we are
+// demonstrating.
+const char *public_data = "Hello, world!";
+const char *private_data = "It's a s3kr3t!!!";
+
 #if SAFESIDE_ARM64
 // Local handler necessary for avoiding local/global linking mismatches on ARM.
 // When we use extern char[] declaration for a label defined in assembly, the

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -33,12 +33,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-// Objective: given some control over accesses to the *non-secret* string
-// "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" that is
-// stored only in the kernel memory.
-const char *public_data = "Hello, world!";
 
 // Leaks the byte that is physically located at &text[0] + offset, without
 // really loading it. In the abstract machine, and in the code executed by the

--- a/demos/meltdown_ac.cc
+++ b/demos/meltdown_ac.cc
@@ -48,10 +48,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 // Storage for the public data.
 // Must be at least a native word size. That's why we pick uintptr_t.

--- a/demos/meltdown_br.cc
+++ b/demos/meltdown_br.cc
@@ -40,10 +40,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 // ICC requires the offset variable to be volatile. If it isn't, ICC schedules
 // to spill it to stack after the second ForceRead call and that never happens

--- a/demos/meltdown_ss.cc
+++ b/demos/meltdown_ss.cc
@@ -60,7 +60,7 @@ static void SetupSegment(int index, const char *base, bool present) {
   memset(&table_entry, 0, sizeof(struct user_desc));
   table_entry.entry_number = index;
   // We must shift the base address one byte below to bypass the minimal segment
-  // size that is one byte.
+  // size which is one byte.
   table_entry.base_addr = reinterpret_cast<unsigned int>(base - 1);
   // No size limit for a present segment, one byte for a non-present segment.
   // Limit is the offset of the last accessible byte, so even a value of zero

--- a/demos/meltdown_ss.cc
+++ b/demos/meltdown_ss.cc
@@ -50,13 +50,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-// Have one dummy character on the beginning of the private data. Segment limit
-// zero means that exactly one address is accessible. We want to access only
-// non-accessible characters.
-const char *private_data = " It's a s3kr3t!!!";
-const char *public_data = "Hello, world!";
 
 // Sets up a segment descriptor in the local descriptor table.
 static void SetupSegment(int index, const char *base, bool present) {
@@ -64,7 +59,9 @@ static void SetupSegment(int index, const char *base, bool present) {
   struct user_desc table_entry;
   memset(&table_entry, 0, sizeof(struct user_desc));
   table_entry.entry_number = index;
-  table_entry.base_addr = reinterpret_cast<unsigned int>(base);
+  // We must shift the base address one byte below to bypass the minimal segment
+  // size that is one byte.
+  table_entry.base_addr = reinterpret_cast<unsigned int>(base - 1);
   // No size limit for a present segment, one byte for a non-present segment.
   // Limit is the offset of the last accessible byte, so even a value of zero
   // creates a one-byte segment.
@@ -179,9 +176,7 @@ int main() {
   SetupSegment(0, public_data, true);
   std::cout << "Leaking the string: ";
   std::cout.flush();
-  // Avoid the first dummy character that would be accessible using zero
-  // segment limit. Therefore starting from index 1.
-  for (size_t i = 1; i < strlen(private_data); ++i) {
+  for (size_t i = 0; i < strlen(private_data); ++i) {
     std::cout << LeakByte(i);
     std::cout.flush();
   }

--- a/demos/meltdown_ud.cc
+++ b/demos/meltdown_ud.cc
@@ -33,11 +33,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
-#include "local_labels.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 static char LeakByte(const char *data, size_t offset) {
   CacheSideChannel sidechannel;

--- a/demos/ret2spec.cc
+++ b/demos/ret2spec.cc
@@ -20,14 +20,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-// TODO(asteinha) Implement support for MSVC and Windows.
-// TODO(asteinha) Investigate the exploitability of PowerPC.
-
-// Private data that is accessed only speculatively. The architectural access
-// to it is unreachable in the control flow.
-const char *private_data = "It's a s3kr3t!!!";
 
 // Global variable stores for avoiding to pass data through function arguments.
 size_t current_offset;

--- a/demos/ret2spec_cyclic.cc
+++ b/demos/ret2spec_cyclic.cc
@@ -36,9 +36,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *private_data = "It's a s3kr3t!!!";
 
 // Recursion depth should be equal or greater than the RSB size, but not
 // excessively high because of the possibility of stack overflow.

--- a/demos/spectre_v1.cc
+++ b/demos/spectre_v1.cc
@@ -20,15 +20,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-// Objective: given some control over accesses to the *non-secret* string
-// "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" without
-// ever accessing it in the C++ execution model, using speculative execution and
-// side channel attacks
-//
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 // Leaks the byte that is physically located at &text[0] + offset, without ever
 // loading it. In the abstract machine, and in the code executed by the CPU,

--- a/demos/spectre_v4.cc
+++ b/demos/spectre_v4.cc
@@ -22,15 +22,9 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
 
-// Objective: given some control over accesses to the *non-secret* string
-// "Hello, world!", construct a program that obtains "It's a s3kr3t!!!" without
-// ever accessing it in the C++ execution model, using speculative execution and
-// side channel attacks
-//
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 constexpr size_t kArrayLength = 64;
 
 // Leaks the byte that is physically located at &text[0] + offset, without ever

--- a/demos/speculation_over_hw_breakpoint.cc
+++ b/demos/speculation_over_hw_breakpoint.cc
@@ -43,10 +43,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 static char LeakByte(const char *data, size_t data_length, size_t offset) {
   CacheSideChannel sidechannel;

--- a/demos/speculation_over_sw_breakpoint.cc
+++ b/demos/speculation_over_sw_breakpoint.cc
@@ -36,10 +36,7 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
-#include "local_labels.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
+#include "local_content.h"
 
 static char LeakByte(const char *data, size_t offset) {
   CacheSideChannel sidechannel;

--- a/demos/speculation_over_syscall.cc
+++ b/demos/speculation_over_syscall.cc
@@ -35,11 +35,8 @@
 
 #include "cache_sidechannel.h"
 #include "instr.h"
-#include "local_labels.h"
+#include "local_content.h"
 #include "utils.h"
-
-const char *public_data = "Hello, world!";
-const char *private_data = "It's a s3kr3t!!!";
 
 static char LeakByte(const char *data, size_t offset) {
   CacheSideChannel sidechannel;


### PR DESCRIPTION
Leaving out the Spectre v1 BTB examples for now.