### PR TITLE
Enable clang-tidy in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,31 @@
+---
+
+# Inspired by https://github.com/googleapis/google-cloud-cpp/blob/master/.clang-tidy
+
+Checks: >-
+  -*,
+  google-*,
+  readability-identifier-naming,
+
+WarningsAsErrors: '*'
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,               value: CamelCase  }
+  - { key: readability-identifier-naming.ConstexprVariableCase,   value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix, value: k }
+  - { key: readability-identifier-naming.EnumConstantCase,        value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,      value: k }
+  - { key: readability-identifier-naming.FunctionCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.GlobalConstantCase,      value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,    value: k }
+  - { key: readability-identifier-naming.MacroDefinitionCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberConstantCase,      value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,    value: k }
+  - { key: readability-identifier-naming.NamespaceCase,           value: lower_case  }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,     value: _ }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,   value: _ }
+  - { key: readability-identifier-naming.StaticConstantCase,      value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,    value: k }
+  - { key: readability-identifier-naming.StructCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,   value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,            value: lower_case }

--- a/ci/build
+++ b/ci/build
@@ -20,7 +20,7 @@ case "${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}" in
   linux_clang)
     sudo apt install "linux-headers-$(uname -r)"
 
-    generate_and_build build
+    generate_and_build build -DCMAKE_CXX_CLANG_TIDY=clang-tidy
     ;;
 
   osx_clang)

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -23,7 +23,7 @@
 
 // Returns the indices of the biggest and second-biggest values in the range.
 template <typename RangeT>
-static std::pair<size_t, size_t> top_two_indices(const RangeT &range) {
+static std::pair<size_t, size_t> TwoTwoIndices(const RangeT &range) {
   std::pair<size_t, size_t> result = {0, 0};  // first biggest, second biggest
   for (size_t i = 0; i < range.size(); ++i) {
     if (range[i] > range[result.first]) {
@@ -108,7 +108,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
     }
   }
 
-  std::tie(best_val, runner_up_val) = top_two_indices(scores_);
+  std::tie(best_val, runner_up_val) = TwoTwoIndices(scores_);
   return std::make_pair((scores_[best_val] > 2 * scores_[runner_up_val] + 40),
                         best_val);
 }

--- a/demos/spectre_v1_pht_sa.cc
+++ b/demos/spectre_v1_pht_sa.cc
@@ -37,8 +37,8 @@ static char LeakByte(const char *data, size_t offset) {
   // The size needs to be unloaded from cache to force speculative execution
   // to guess the result of comparison.
   //
-  // TODO: since size_in_heap is no longer the only heap-allocated value, it
-  // should be allocated into its own unique page
+  // TODO(asteinha): since size_in_heap is no longer the only heap-allocated
+  // value, it should be allocated into its own unique page
   std::unique_ptr<size_t> size_in_heap = std::unique_ptr<size_t>(
       new size_t(strlen(data)));
 


### PR DESCRIPTION
For now, mostly for formatting things like casing that `clang-format` doesn't see.

Enable `WarningsAsErrors` to block CI, like: https://travis-ci.org/google/safeside/jobs/611644241