### PR TITLE
Pass OS and CPUs to add_demo

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -21,13 +21,34 @@ endif()
 # Support library
 add_library(safeside cache_sidechannel.cc instr.cc utils.cc)
 
-# Takes care of the common case for demo programs: an executable target
-# that compiles a file of the same name and links against the Safeside
-# support library.
+# Defines an executable target named `demo_name` built from `demo_name.cc` and
+# linked against the Safeside support library. The caller can also use the
+# SYSTEMS and PROCESSORS keywords to restrict when the target should be
+# created.
 function(add_demo demo_name)
+  cmake_parse_arguments(
+    ARG  # parsed argument prefix
+    ""  # boolean options
+    ""  # one-value arguments
+    "SYSTEMS;PROCESSORS"  # multi-value arguments
+    ${ARGN}  # arguments to parse -- ARGN excludes already-named arguments
+  )
+
+  if (DEFINED ARG_SYSTEMS)
+    if (NOT ${CMAKE_SYSTEM_NAME} IN_LIST ARG_SYSTEMS)
+      return()
+    endif()
+  endif()
+
+  if (DEFINED ARG_PROCESSORS)
+    if (NOT ${CMAKE_SYSTEM_PROCESSOR} IN_LIST ARG_PROCESSORS)
+      return()
+    endif()
+  endif()
+
   add_executable(${demo_name} ${demo_name}.cc)
   target_link_libraries(${demo_name} safeside)
-endfunction(add_demo)
+endfunction()
 
 # Spectre V1 PHT SA -- mistraining PHT in the same address space
 add_demo(spectre_v1_pht_sa)
@@ -41,71 +62,57 @@ add_demo(spectre_v4)
 # Ret2Spec -- rewriting the RSB using recursion in the same address space
 add_demo(ret2spec_sa)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$")
-  # Spectre V1 BTB CA - mistraining BTB from another address space
-  add_demo(spectre_v1_btb_ca)
+# Spectre V1 BTB CA - mistraining BTB from another address space
+add_demo(spectre_v1_btb_ca SYSTEMS Linux)
+
+# Ret2Spec -- speculative execution using return stack buffers creating a
+# call-ret disparity by inline assembly
+add_demo(ret2spec_callret_disparity
+         SYSTEMS Linux Darwin
+         PROCESSORS i386 x86_64 aarch64)
+if (TARGET ret2spec_callret_disparity)
+  target_compile_options(ret2spec_callret_disparity
+                         PRIVATE -fomit-frame-pointer)
 endif()
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)|(Darwin)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)|(x86_64)|(aarch64)$"))
-  # Ret2Spec -- speculative execution using return stack buffers creating a
-  # call-ret disparity by inline assembly
-  add_demo(ret2spec_callret_disparity)
-  target_compile_options(ret2spec_callret_disparity PRIVATE -fomit-frame-pointer)
-endif()
+# Spectre V3 / Meltdown
+add_demo(meltdown SYSTEMS Linux PROCESSORS i686 x86_64 ppc64le)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)|(x86_64)|(ppc64le)$"))
-  # Spectre V3 / Meltdown
-  add_demo(meltdown)
+# L1 terminal fault -- Foreshadow OS -- Meltdown P
+add_demo(l1tf SYSTEMS Linux PROCESSORS i686 x86_64 ppc64le)
 
-  # L1 terminal fault -- Foreshadow OS -- Meltdown P
-  add_demo(l1tf)
-endif()
+# Speculation over ERET, HVC and SMC instructions
+add_demo(eret_hvc_smc_wrapper SYSTEMS Linux PROCESSORS aarch64)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(aarch64)$"))
-  # Speculation over ERET, HVC and SMC instructions
-  add_demo(eret_hvc_smc_wrapper)
+# Speculation over syscall
+add_demo(speculation_over_syscall SYSTEMS Linux PROCESSORS aarch64)
 
-  # Speculation over syscall
-  add_demo(speculation_over_syscall)
+# Meltdown UD -- speculation over an undefined instruction
+add_demo(meltdown_ud SYSTEMS Linux PROCESSORS aarch64)
 
-  # Meltdown UD -- speculation over an undefined instruction
-  add_demo(meltdown_ud)
-endif()
+# Meltdown BR - speculation over the ia32 bounds check instruction
+add_demo(meltdown_br SYSTEMS Linux Darwin PROCESSORS i686)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)|(Darwin)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)$"))
-   # Meltdown BR - speculation over the ia32 bounds check instruction
-  add_demo(meltdown_br)
-endif()
+# Meltdown SS -- speculative reading from non present segments and outside of
+# segment limits
+add_demo(meltdown_ss SYSTEMS Linux PROCESSORS i686)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)$"))
-  # Meltdown SS -- speculative reading from non present segments and outside of
-  # segment limits
-  add_demo(meltdown_ss)
-endif()
+# Meltdown OF -- speculative fetching from an overflowing address after an
+# INTO check
+add_demo(meltdown_of SYSTEMS Linux Darwin PROCESSORS i686)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)|(Darwin)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)$"))
-  # Meltdown OF -- speculative fetching from an overflowing address after an
-  # INTO check
-  add_demo(meltdown_of)
-endif()
+# Speculation over hardware breakpoint trap (read watcher)
+add_demo(speculation_over_read_hw_breakpoint
+         SYSTEMS Linux
+         PROCESSORS i686 x86_64)
 
-if((${CMAKE_SYSTEM_NAME} MATCHES "^(Linux)$") AND
-   (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86)|(x86_64)$"))
-  # Speculation over hardware breakpoint trap (read watcher)
-  add_demo(speculation_over_read_hw_breakpoint)
+# Speculation over hardware breakpoint fault (execution watcher)
+add_demo(speculation_over_exec_hw_breakpoint
+         SYSTEMS Linux
+         PROCESSORS i686 x86_64)
 
-  # Speculation over hardware breakpoint fault (execution watcher)
-  add_demo(speculation_over_exec_hw_breakpoint)
+# Meltdown AC -- speculative fetching of unaligned data
+add_demo(meltdown_ac SYSTEMS Linux PROCESSORS i686 x86_64)
 
-  # Meltdown AC -- speculative fetching of unaligned data
-  add_demo(meltdown_ac)
-
-  # Meltdown DE -- speculative computation with division by zero remainder
-  add_demo(meltdown_de)
-endif()
+# Meltdown DE -- speculative computation with division by zero remainder
+add_demo(meltdown_de SYSTEMS Linux PROCESSORS i686 x86_64)


### PR DESCRIPTION
Builds on #88. Use parameters to the function to control which OSes and CPUs we build each demo for.