### PR TITLE
Bugfix in the cache sidechannel computation.

### DIFF
--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -24,7 +24,7 @@
 // Returns the indices of the biggest and second-biggest values in the range.
 template <typename RangeT>
 static std::pair<size_t, size_t> TwoTwoIndices(const RangeT &range) {
-  std::pair<size_t, size_t> result = {0, 1};  // first biggest, second biggest
+  std::pair<size_t, size_t> result = {256, 256};  // first and second biggest
   for (size_t i = 0; i < range.size(); ++i) {
     if (range[i] > range[result.first]) {
       result.second = result.first;

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -24,7 +24,7 @@
 // Returns the indices of the biggest and second-biggest values in the range.
 template <typename RangeT>
 static std::pair<size_t, size_t> TwoTwoIndices(const RangeT &range) {
-  std::pair<size_t, size_t> result = {0, 0};  // first biggest, second biggest
+  std::pair<size_t, size_t> result = {0, 1};  // first biggest, second biggest
   for (size_t i = 0; i < range.size(); ++i) {
     if (range[i] > range[result.first]) {
       result.second = result.first;

--- a/demos/cache_sidechannel.h
+++ b/demos/cache_sidechannel.h
@@ -102,5 +102,5 @@ class CacheSideChannel {
   // so it would immediately overflow.
   std::unique_ptr<PaddedOracleArray> padded_oracle_array_ =
       std::unique_ptr<PaddedOracleArray>(new PaddedOracleArray);
-  std::array<int, 256> scores_ = {};
+  std::array<int, 257> scores_ = {};
 };


### PR DESCRIPTION
Current implementation fails when the hit is at index 0 and there is no noise.
In that case the first and second is both 0 and the condition first > 2 * second + 40 is never reached.