### PR TITLE
Universal implementation of Meltdown-DE

### DIFF
--- a/demos/meltdown_de.cc
+++ b/demos/meltdown_de.cc
@@ -15,7 +15,7 @@
  */
 
 /**
- * Demonstrates the Meltdown-DE on AMD and Intel.
+ * Demonstrates the Meltdown-DE on x86/64.
  **/
 
 #include "compiler_specifics.h"


### PR DESCRIPTION
Trying to encapsulate Meltdown-DE into string leaking does not seem to be useful.
Providing a more demonstrative solution that should work on all affected CPUs.