### PR TITLE
Run Spectre V1 demo as a smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - name: "Linux / clang / x86_64"
       os: linux
       compiler: clang
-    - name: "Linux / gcc / x86_64, i386"
+    - name: "Linux / gcc / x86_64, i686"
       os: linux
       compiler: gcc
     - name: "Linux / gcc / aarch64"
@@ -27,3 +27,4 @@ matrix:
       # CMake picks up MSVC regardless of what compiler we specify here.
 script:
   - ./ci/build
+  - ./ci/test

--- a/ci/build
+++ b/ci/build
@@ -44,9 +44,12 @@ case "${OS_COMPILER_CPU}" in
     ;;
 
   linux_gcc_x86_64)
+    # Install the 32-bit compiler and C/C++ runtimes
     apt_install \
         "linux-headers-$(uname -r)" \
-        g++-i686-linux-gnu
+        g++-i686-linux-gnu \
+        libc6:i386 \
+        libstdc++6:i386
 
     generate_and_build build-x86_64
     generate_and_build build-i686 \

--- a/ci/test
+++ b/ci/test
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+set -o xtrace
+
+# Straightforward and ugly for now: run the `spectre_v1_pht_sa` demo as a test
+# by looking for it anywhere we might have built it.
+
+[[ -x ./build/demos/spectre_v1_pht_sa ]] &&
+    ./build/demos/spectre_v1_pht_sa
+[[ -x ./build-x86_64/demos/spectre_v1_pht_sa ]] &&
+    ./build-x86_64/demos/spectre_v1_pht_sa
+[[ -x ./build-i686/demos/spectre_v1_pht_sa ]] &&
+    ./build-i686/demos/spectre_v1_pht_sa
+[[ -x ./build-win32/demos/Debug/spectre_v1_pht_sa.exe ]] &&
+    ./build-win32/demos/Debug/spectre_v1_pht_sa.exe
+[[ -x ./build-x64/demos/Debug/spectre_v1_pht_sa.exe ]] &&
+    ./build-x64/demos/Debug/spectre_v1_pht_sa.exe
+
+# Avoid a nonzero exit code. Otherwise we'll return the exit code of our last
+# command, which is often an unsatisfied [[ -x ... ]] condition.
+true


### PR DESCRIPTION
Seems like this will be useful as an integration test to make sure e.g. our
CacheSideChannel flush+reload code is working. Next tests to add will be
others that work across most/all platforms.

For now, I added a *very* quick and dirty test runner that just probes for
all the places the built Spectre V1 demo could be.

I had to add 32-bit runtime files for the Linux x86_64 worker. It's obvious
in hindsight why they're necessary, but the error message you get when
they're not present is just "file not found" which is a bit obscure. Turns
out the binary's header points to an ELF interpreter (`/lib/ld-linux.so.2`)
that doesn't exist until `libc6:i386` is installed.

Once that's in place, the binary can actually try to load and get far enough
to complain about the missing `libstdc++`.