### PR TITLE
Add more detail on LFENCE on AMD processors

### DIFF
--- a/demos/asm/measurereadlatency_x86_64.S
+++ b/demos/asm/measurereadlatency_x86_64.S
@@ -30,24 +30,31 @@ DECORATE(MeasureReadLatency):
 
   // Serialize the instruction stream and finish all memory operations.
   //
-  // LFENCE[1] waits for all prior instructions to complete before allowing any
-  // later instructions to start, but (as the name would suggest) it doesn't
-  // wait for memory operations other than loads to complete. So we add an
-  // MFENCE[2], which is a full memory barrier but does not serialize the
+  // LFENCE[1] waits for all prior instructions to complete[2] before allowing
+  // any later instructions to start, but (as the name would suggest) it
+  // doesn't wait for memory operations other than loads to complete. So we add
+  // an MFENCE[3], which is a full memory barrier but does not serialize the
   // instruction stream, followed by an LFENCE. The LFENCE must come second so
   // that it will wait for the MFENCE to complete.
   //
   // MFENCE also waits for prior CLFLUSH and CLFLUSHOPT instructions to finish
-  // before continuing.[3]
+  // before continuing.[4]
   //
-  // See also: the FLUSH+RELOAD paper[4], specifically Figure 4 on page 5 and
+  // See also: the FLUSH+RELOAD paper[5], specifically Figure 4 on page 5 and
   // the accompanying explanation.
   //
   // [1] LFENCE: https://cpu.fyi/d/484#G5.136804
-  // [2] MFENCE: https://cpu.fyi/d/484#G7.864843
-  // [3] "Memory Ordering in P6 and More Recent Processor Families":
+  // [2] At least, on Intel processors. LFENCE is _not_ documented as
+  //   serializing on AMD processors (https://cpu.fyi/d/ad5#G9.3072402), but
+  //   in early 2018 AMD documented a model-specific register (MSR) that
+  //   system software can set to make LFENCE serializing on basically all
+  //   existing and future AMD processors. (See page 3 of
+  //   https://web.archive.org/web/20180219210500/https://developer.amd.com/wp-content/resources/Managing-Speculation-on-AMD-Processors.pdf.)
+  //   This MSR has been set in Linux since v4.15: https://git.io/JePgI
+  // [3] MFENCE: https://cpu.fyi/d/484#G7.864843
+  // [4] "Memory Ordering in P6 and More Recent Processor Families":
   //   https://cpu.fyi/d/749#G13.31870
-  // [4] FLUSH+RELOAD: https://eprint.iacr.org/2013/448.pdf
+  // [5] FLUSH+RELOAD: https://eprint.iacr.org/2013/448.pdf
   mfence
   lfence
 


### PR DESCRIPTION
I might be enjoying this too much. I almost used a footnote inside a footnote.