### PR TITLE
`TimingArray` with new API and threshold technique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Assumes a workflow of:
-#     cmake -B build .
-#     make -C build
 /build/
+/build-*/
+
+.vscode/

--- a/ci/test
+++ b/ci/test
@@ -1,22 +1,40 @@
 #!/bin/bash
 
 set -o errexit -o nounset -o pipefail
-set -o xtrace
 
-# Straightforward and ugly for now: run the `spectre_v1_pht_sa` demo as a test
-# by looking for it anywhere we might have built it.
+TEST_DIRS="
+./build/demos
+./build-x86_64/demos
+./build-i686/demos
+./build-win32/demos/Debug
+./build-x64/demos/Debug
+"
 
-[[ -x ./build/demos/spectre_v1_pht_sa ]] &&
-    ./build/demos/spectre_v1_pht_sa
-[[ -x ./build-x86_64/demos/spectre_v1_pht_sa ]] &&
-    ./build-x86_64/demos/spectre_v1_pht_sa
-[[ -x ./build-i686/demos/spectre_v1_pht_sa ]] &&
-    ./build-i686/demos/spectre_v1_pht_sa
-[[ -x ./build-win32/demos/Debug/spectre_v1_pht_sa.exe ]] &&
-    ./build-win32/demos/Debug/spectre_v1_pht_sa.exe
-[[ -x ./build-x64/demos/Debug/spectre_v1_pht_sa.exe ]] &&
-    ./build-x64/demos/Debug/spectre_v1_pht_sa.exe
+# Straightforward and ugly for now: given a test name, look for everywhere we
+# could have built it, and run what we find. Exit on first failure.
+# Usage:
+#   run_test <test_name>
+run_test() {
+  local test_name=$1
 
-# Avoid a nonzero exit code. Otherwise we'll return the exit code of our last
-# command, which is often an unsatisfied [[ -x ... ]] condition.
-true
+  for test_dir in $TEST_DIRS; do
+    test_bin=${test_dir}/${test_name}
+
+    if [[ -x "${test_bin}.exe" ]]; then
+      test_bin=${test_bin}.exe
+    fi
+
+    if [[ -x "${test_bin}" ]]; then
+      echo "== BEGIN    ${test_bin}"
+      TIMEFORMAT='== END      %2R seconds'
+      time "${test_bin}" || (
+        echo "== FAILED   return code $?"
+        exit 1
+      )
+      echo
+    fi
+  done
+}
+
+run_test timing_array_test
+run_test spectre_v1_pht_sa

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -2,14 +2,38 @@
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS off)
 
-# Enable at least some optimization in all builds. The Ret2Spec demo, in
-# particular, will segfault if built without optimizations.
-# TODO(https://git.io/JecmX): Fix the crash in Ret2Spec
-add_compile_options(-O2)
+# Enable (or at least don't disable) some optimizations in all builds.
+# Without optimizations, it can be difficult to fit enough useful code into the
+# speculative execution window.
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  # Remove a few optimization-related MSVC flags that CMake includes in Debug
+  # builds by default: https://git.io/Jv0F0
 
-# Disable run-time code checking on MSVC. It's enabled by default in CMake's
-# debug build settings, but it's incompatible with optimizations.
-string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+  # Remove `/Od`, which disables all optimizations.
+  # https://docs.microsoft.com/en-us/cpp/build/reference/od-disable-debug?view=vs-2019
+  string(REPLACE "/Od" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+  # Remove `/Ob0`, which disables *all* function inlining -- even for functions
+  # marked `__forceinline`.
+  # https://docs.microsoft.com/en-us/cpp/build/reference/ob-inline-function-expansion?view=vs-2019
+  string(REPLACE "/Ob0" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+  # Remove `/RTC1`, which enables run-time error checks. These checks are
+  # incompatible with optimizations and the build fails if both are enabled.
+  # https://docs.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=vs-2019
+  string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+else()
+  # Enable baseline optimizations (`-O1`) in the generic C++ build flags for
+  # all build types.
+  #
+  # Some experiments show that flags in `CMAKE_CXX_FLAGS` appear on the
+  # compiler command line before those in `CMAKE_CXX_FLAGS_<CONFIG>` or added
+  # with `add_compile_options()`. Since Clang and GCC use the last `-O` option,
+  # that means we won't clobber a higher optimization setting used by release
+  # builds. For example, `CMAKE_<LANG>_FLAGS_RELEASE` includes `-O3` by default
+  # when compiling with a GCC-compatible toolchain (see https://git.io/Jv0xu).
+  string(APPEND CMAKE_CXX_FLAGS " -O1")
+endif()
 
 # When targeting x86, we need to opt in to SSE2 instructions like
 # clflush, mfence, lfence.

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -43,7 +43,12 @@ if(("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(i.86)$") AND
 endif()
 
 # Support library
-add_library(safeside cache_sidechannel.cc instr.cc utils.cc)
+add_library(safeside
+  cache_sidechannel.cc
+  instr.cc
+  timing_array.cc
+  utils.cc
+)
 
 # Configure the assembler. Set ASM_EXT (extension for assembly files) and
 # ASM_PLATFORM (target CPU), which we'll use to add the right assembly
@@ -85,6 +90,11 @@ target_sources(
   PRIVATE
     asm/measurereadlatency_${ASM_PLATFORM}.${ASM_EXT}
 )
+
+# Support library tests
+
+add_executable(timing_array_test timing_array_test.cc)
+target_link_libraries(timing_array_test safeside)
 
 # Defines an executable target named `demo_name` built from `demo_name.cc` and
 # linked against the Safeside support library. The caller can also use the

--- a/demos/timing_array.cc
+++ b/demos/timing_array.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#include "timing_array.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "asm/measurereadlatency.h"
+#include "instr.h"
+#include "utils.h"
+
+TimingArray::TimingArray() {
+  // Explicitly initialize the elements of the array.
+  //
+  // It's not important what value we write as long as we force *something* to
+  // be written to each element. Otherwise, the backing allocation could be a
+  // range of zero-fill-on-demand (ZFOD), copy-on-write pages that all start
+  // off mapped to the same physical page of zeros. Since the cache on modern
+  // Intel CPUs is physically tagged, some elements might map to the same cache
+  // line and we wouldn't observe a timing difference between reading accessed
+  // and unaccessed elements.
+  for (int i = 0; i < size(); ++i) {
+    ElementAt(i) = -1;
+  }
+
+  // Init the first time through, then keep for later instances.
+  static uint64_t threshold = FindCachedReadLatencyThreshold();
+  cached_read_latency_threshold_ = threshold;
+}
+
+void TimingArray::FlushFromCache() {
+  // We only need to flush the cache lines with elements on them.
+  for (int i = 0; i < size(); ++i) {
+    CLFlush(&ElementAt(i));
+  }
+}
+
+int TimingArray::FindFirstCachedElementIndexAfter(int start_after) {
+  // Fail if element is out of bounds.
+  if (start_after >= size()) {
+    return -1;
+  }
+
+  // Start at the element after `start_after`, wrapping around until we've
+  // found a cached element or tried every element.
+  for (int i = 1; i <= size(); ++i) {
+    int el = (start_after + i) % size();
+    uint64_t read_latency = MeasureReadLatency(&ElementAt(el));
+    if (read_latency <= cached_read_latency_threshold_) {
+      return el;
+    }
+  }
+
+  // Didn't find a cached element.
+  return -1;
+}
+
+int TimingArray::FindFirstCachedElementIndex() {
+  // Start "after" the last element, which means start at the first.
+  return FindFirstCachedElementIndexAfter(size() - 1);
+}
+
+// Determines a threshold value (as returned from MeasureReadLatency) at or
+// below which it is very likely the value was read from the cache without
+// going to main memory.
+//
+// There are a *lot* of potential approaches for finding such a threshold
+// value. Ours is, roughly:
+//   1. Read all the elements of a TimingArray into cache.
+//   2. Read all elements again, in the same order, measuring how long each
+//      read takes and remembering the latency of the slowest read.
+//   3. Repeat (1) and (2) many times to get a lot of "slowest read from a
+//      cached array" data points.
+//   4. Sort those data points and take a value at a low percentile.
+//
+// We try to make our code to *find* the threshold as similar as possible as
+// code elsewhere that *uses* it. Reading the whole array each time and taking
+// the slowest read helps us account for effects that only happen when reading
+// many values:
+//   - TimingArray forces values onto different pages, which introduces TLB
+//     pressure. After re-reading ~64 elements of a 256-element array on an
+//     Intel Xeon processor, we see latency increase as we start hitting the L2
+//     TLB. The 7-Zip LZMA benchmarks have some useful measurements on this:
+//     https://www.7-cpu.com/cpu/Skylake.html
+//   - Our first version of TimingArray didn't implement cache coloring and all
+//     elements were contending for the same cache set. As a result, after
+//     reading 256 values, we had evicted all but the first ~8 from the L1
+//     cache. Our threshold computation took this into account. If we had just
+//     looped over reading one memory value, the computed threshold would have
+//     been too low to classify reads from L2 or L3 cache.
+//
+// Repeating the experiment many times and taking a low-percentile value helps
+// us control for effects that would otherwise skew the threshold too high:
+//   - A context switch might happen right before a measurement, evicting array
+//     elements from the cache; or one could happen *during* a measurement,
+//     adding arbitrary extra time to the observed latency.
+//   - A coscheduled hyperthread might introduce cache contention, forcing some
+//     reads to go to memory.
+//
+// Ultimately, our approach assumes:
+//   - Read latencies are a right-skewed distribution, with a left boundary at
+//     the fastest possible read from cache, a mode value slightly above that
+//     speed-of-light value, and a long right tail of slow or interrupted
+//     reads.
+//   - Context switches and contention happen, but not too often.
+//
+// The idea of taking a low-percentile value is inspired in part by
+// observations from "Opportunities and Limits of Remote Timing Attacks"[1].
+//
+// [1] https://www.cs.rice.edu/~dwallach/pub/crosby-timing2009.pdf
+uint64_t TimingArray::FindCachedReadLatencyThreshold() {
+  const int iterations = 1000;
+  const int percentile = 10;
+
+  // Accumulates the highest read latency seen in each iteration.
+  std::vector<uint64_t> max_read_latencies;
+
+  for (int n = 0; n < iterations; ++n) {
+    // Bring all elements into cache.
+    for (int i = 0; i < size(); ++i) {
+      ForceRead(&ElementAt(i));
+    }
+
+    // Read each element and keep track of the slowest read.
+    uint64_t max_read_latency = std::numeric_limits<uint64_t>::min();
+    for (int i = 0; i < size(); ++i) {
+      max_read_latency =
+          std::max(max_read_latency, MeasureReadLatency(&ElementAt(i)));
+    }
+
+    max_read_latencies.push_back(max_read_latency);
+  }
+
+  // Find and return the `percentile` max read latency value.
+  std::sort(max_read_latencies.begin(), max_read_latencies.end());
+  int index = (percentile / 100.0) * (max_read_latencies.size() - 1);
+  return max_read_latencies[index];
+}

--- a/demos/timing_array.h
+++ b/demos/timing_array.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_TIMING_ARRAY_H_
+#define DEMOS_TIMING_ARRAY_H_
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "hardware_constants.h"
+
+// TimingArray is an indexable container that makes it easy to induce and
+// measure cache timing side-channels to leak the value of a single byte.
+//
+// TimingArray goes to some trouble to make sure that element accesses do not
+// interfere with the cache presence of other elements.
+//
+// Specifically:
+//   - Each element is on its own physical page of memory, which usually
+//     prevents interference from hardware prefetchers.[1]
+//   - Elements' order in memory is different than their index order, which
+//     further frustrates hardware prefetchers by avoiding memory accesses at
+//     any repeated stride.
+//   - Elements are distributed across cache sets -- as opposed to e.g. always
+//     being at offset 0 within a page -- which reduces contention within cache
+//     sets, optimizing the use of L1 and L2 caches and therefore improving
+//     side-channel signal by increasing the timing difference between cached
+//     and uncached accesses.
+//
+// TimingArray also includes convenience functions for cache manipulation and
+// timing measurement.
+//
+// Example use:
+//
+//     TimingArray ta;
+//     int i = -1;
+//
+//     // Loop until we're sure we saw an element come from cache
+//     while (i == -1) {
+//       ta.FlushFromCache();
+//       ForceRead(&ta[4]);
+//       i = ta.FindFirstCachedElementIndex();
+//     }
+//     std::cout << "item " << i << " was in cache" << std::endl;
+//
+// [1] See e.g. Intel's documentation at https://cpu.fyi/d/83c#G3.1121453,
+//   which says data is only prefetched if it is on the "same 4K byte page".
+
+class TimingArray {
+ public:
+  // ValueType is an alias for the element type of the array. Someday we might
+  // want to make TimingArray a template class and take this as a parameter,
+  // but for now the flexibility isn't worth the extra hassle.
+  using ValueType = int;
+
+  // This could likewise be a parameter and, likewise, isn't. Making the array
+  // smaller doesn't improve the bandwidth of the side-channel, and trying to
+  // leak more than a byte at a time significantly increases noise due to
+  // greater cache contention.
+  //
+  // "Real" elements because we add buffer elements before and after. See
+  // comment on `elements_` below.
+  static const size_t kRealElements = 256;
+
+  TimingArray();
+
+  TimingArray(TimingArray&) = delete;
+  TimingArray& operator=(TimingArray&) = delete;
+
+  ValueType& operator[](size_t i) {
+    // Map index to element.
+    //
+    // As mentioned in the class comment, we try to frustrate hardware
+    // prefetchers by applying a permutation so elements don't appear in memory
+    // in index order. The mapping is pretty simple: we multiply by an odd
+    // number and mod by 256. Any odd number 1<n<256 will cover the range, but
+    // we choose one that generates a sufficiently "random-looking" sequence.
+    // We also add an offset so that the first element isn't first in memory.
+    static_assert(kRealElements == 256, "consider changing 113");
+    size_t el = (100 + i*113) % kRealElements;
+
+    // Add 1 to skip leading buffer element.
+    return elements_[1 + el].cache_lines[0].value;
+  }
+
+  // We intentionally omit the "const" accessor:
+  //    const ValueType& operator[](size_t i) const { ... }
+  //
+  // At the level of abstraction we care about, accessing an element at all
+  // (even to read it) is not "morally const" since it mutates cache state.
+
+  size_t size() const { return kRealElements; }
+
+  // Flushes all elements of the array from the cache.
+  void FlushFromCache();
+
+  // Reads elements of the array in index order, starting with index 0, and
+  // looks for the first read that was fast enough to have come from the cache.
+  //
+  // Returns the index of the first "fast" element, or -1 if no element was
+  // obviously read from the cache.
+  //
+  // This function uses a heuristic that errs on the side of false *negatives*,
+  // so it is common to use it in a loop. Of course, measuring the time it
+  // takes to read an element has the side effect of bringing that element into
+  // the cache, so the loop must include a cache flush and re-attempt the
+  // side-channel leak.
+  int FindFirstCachedElementIndex();
+
+  // Just like `FindFirstCachedElementIndex`, except it begins right *after*
+  // the index `start_after`, wrapping around to try all array elements. That
+  // is, the first element read is `(start_after+1) % size` and the last
+  // element read before returning -1 is `start_after`.
+  int FindFirstCachedElementIndexAfter(int start_after);
+
+  // Returns the threshold value used by FindFirstCachedElementIndex to
+  // identify reads that came from cache.
+  uint64_t cached_read_latency_threshold() const {
+    return cached_read_latency_threshold_;
+  }
+
+ private:
+  // Convenience so we don't have (*this)[i] everywhere.
+  ValueType& ElementAt(size_t i) { return (*this)[i]; }
+
+  uint64_t cached_read_latency_threshold_;
+  uint64_t FindCachedReadLatencyThreshold();
+
+  // Define a struct that is the size of a cache line. Even though we use
+  // `alignas`, there's no guarantee (up through C++17) that the struct will
+  // actually be allocated at that alignment in the common case where
+  //     kCacheLineBytes > sizeof(std::max_align_t)
+  // See the discussion of "extended alignment" requirements at
+  // https://en.cppreference.com/w/cpp/language/object#Alignment
+  struct alignas(kCacheLineBytes) CacheLineSized {
+    ValueType value;
+  };
+  static_assert(sizeof(CacheLineSized) == kCacheLineBytes, "");
+
+  // Define our "Element" struct, which will be the size of one page of memory
+  // plus one cache line. When we allocate N of these in an array, we can't
+  // tell if they'll be cache-aligned, but we know that the start of adjacent
+  // elements will be on different pages *and* different cache lines.
+  static const int kCacheLinesPerPage = kPageBytes / kCacheLineBytes;
+  struct Element {
+    std::array<CacheLineSized, kCacheLinesPerPage + 1> cache_lines;
+  };
+  static_assert(sizeof(Element) == kPageBytes + kCacheLineBytes, "");
+
+  // The actual backing store for the timing array, with buffer elements before
+  // and after to avoid interference from adjacent heap allocations.
+  //
+  // We use `vector` here instead of `array` to avoid problems where
+  // `TimingArray` is put on the stack and the class is so large it skips past
+  // the stack guard page. This is more likely on PowerPC where the page size
+  // (and therefore our element stride) is 64K.
+  std::vector<Element> elements_{1 + kRealElements + 1};
+};
+
+#endif  // DEMOS_TIMING_ARRAY_H_

--- a/demos/timing_array_test.cc
+++ b/demos/timing_array_test.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#include "timing_array.h"
+
+#include <iostream>
+
+#include "instr.h"
+#include "utils.h"
+
+// Measure how often TimingArray is able to accurately determine which element
+// was read into cache. Fail the test early if the *wrong* element is ever read
+// (vs. the benign "no result").
+int main(int argc, char* argv[]) {
+  TimingArray ta;
+
+  std::cout << "Cached read latency threshold is "
+            << ta.cached_read_latency_threshold() << std::endl;
+
+  const int attempts = 10000;
+  int successes = 0;
+
+  for (int n = 0; n < attempts; ++n) {
+    // Choose a random byte and attempt to leak it through the cache timing
+    // side-channel.
+    int el = rand() & 0xff;
+    ta.FlushFromCache();
+    ForceRead(&ta[el]);
+
+    int found = ta.FindFirstCachedElementIndex();
+    if (found == el) {
+      ++successes;
+    } else if (found != -1) {
+      std::cout << "False positive. Found " << found
+                << " instead of " << el
+                << std::endl;
+      exit(1);
+    }
+  }
+
+  std::cout << "Found cached element on the first try "
+            << successes << " of " << attempts << " times." << std::endl;
+
+  // Expect a high percentage of attempts to succeed.
+  bool pass = successes > (attempts * 0.85);
+  return !pass;
+}


### PR DESCRIPTION
`TimingArray` is a new API and implementation for making it easy to induce
and measure cache timing side-channels.

Differences from `CacheSideChannel`:
  - `TimingArray` computes its own threshold for recognizing when a memory
    read came from cache, so callers don't need to induce their own "known
    cached" value. That means no more `AddHitAnd...` variant *and* less
    disruption caused by the "look for cached read" action.
  - The threshold is computed using a pretty simple approach that only looks
    at cached reads.
  - `TimingArray` spreads elements across pages and cache lines, improving
    cache use and therefore side-channel signal.
  - Elements are always accessed in permuted order.
  - Different API for the "look for a cached value other than *this* one"
    gesture common for Spectre variants.

As a motivating example, I ported `spectre_v1_pht_sa` to use the new class
(in part because it runs tests in CI). I also added a new test in CI for
`TimingArray` that fails if it doesn't identify the cached value more than
85% of the time or if it *ever* identifies the wrong cached value.