### PR TITLE
Clean up header guards

### DIFF
--- a/demos/cache_sidechannel.h
+++ b/demos/cache_sidechannel.h
@@ -7,6 +7,9 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
+#ifndef DEMOS_CACHE_SIDECHANNEL_H_
+#define DEMOS_CACHE_SIDECHANNEL_H_
+
 #include <array>
 #include <memory>
 
@@ -97,3 +100,5 @@ class CacheSideChannel {
       std::unique_ptr<PaddedOracleArray>(new PaddedOracleArray);
   std::array<int, 257> scores_ = {};
 };
+
+#endif  // DEMOS_CACHE_SIDECHANNEL_H_

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -7,6 +7,9 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
+#ifndef DEMOS_INSTR_H_
+#define DEMOS_INSTR_H_
+
 #include <cstdint>
 #include <cstring>
 
@@ -279,3 +282,5 @@ inline void SupposedlySafeOffsetAndDereference(const char *address,
 }
 #endif
 #endif
+
+#endif  // DEMOS_INSTR_H_

--- a/demos/local_content.h
+++ b/demos/local_content.h
@@ -7,8 +7,9 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
-#ifndef DEMOS_LOCAL_CONTENT_H
-#define DEMOS_LOCAL_CONTENT_H
+#ifndef DEMOS_LOCAL_CONTENT_H_
+#define DEMOS_LOCAL_CONTENT_H_
+
 // Generic strings used across examples. The public_data is intended to be
 // accessed in the C++ execution model. The content of the private_data is
 // intended to be leaked outside of the C++ execution model using sidechannels.
@@ -16,4 +17,5 @@
 // demonstrating.
 const char *public_data = "Hello, world!";
 const char *private_data = "It's a s3kr3t!!!";
-#endif  // DEMOS_LOCAL_CONTENT_H
+
+#endif  // DEMOS_LOCAL_CONTENT_H_

--- a/demos/meltdown_local_content.h
+++ b/demos/meltdown_local_content.h
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
-#ifndef DEMOS_MELTDOWN_LOCAL_CONTENT_H
-#define DEMOS_MELTDOWN_LOCAL_CONTENT_H
+#ifndef DEMOS_MELTDOWN_LOCAL_CONTENT_H_
+#define DEMOS_MELTDOWN_LOCAL_CONTENT_H_
 
 #include "compiler_specifics.h"
 
@@ -72,4 +72,5 @@ static void OnSignalMoveRipToAfterspeculation(int signal) {
   act.sa_flags = SA_SIGINFO;
   sigaction(signal, &act, nullptr);
 }
-#endif  // DEMOS_MELTDOWN_LOCAL_CONTENT_H
+
+#endif  // DEMOS_MELTDOWN_LOCAL_CONTENT_H_

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
-#ifndef DEMOS_UTILS_H
-#define DEMOS_UTILS_H
+#ifndef DEMOS_UTILS_H_
+#define DEMOS_UTILS_H_
 
 #include "compiler_specifics.h"
 
@@ -24,4 +24,5 @@ inline void ForceRead(const void *p) {
 // Flush a memory interval from cache. Used to induce speculative execution on
 // flushed values until they are fetched back to the cache.
 void FlushFromCache(const char *start, const char *end);
-#endif  // DEMOS_UTILS_H
+
+#endif  // DEMOS_UTILS_H_


### PR DESCRIPTION
Add where missing. Always have blank lines before/after. Always use trailing underscore.