### PR TITLE
Changing some "generic memory" functions to take `void *`

### DIFF
--- a/demos/asm/measurereadlatency.h
+++ b/demos/asm/measurereadlatency.h
@@ -23,6 +23,6 @@
 //
 // Will return spuriously high results if e.g. the thread is preempted while
 // measuring the read.
-extern "C" uint64_t MeasureReadLatency(const char* address);
+extern "C" uint64_t MeasureReadLatency(const void* address);
 
 #endif  // DEMOS_ASM_MEASUREREADLATENCY_H_

--- a/demos/asm/measurereadlatency_aarch64.S
+++ b/demos/asm/measurereadlatency_aarch64.S
@@ -8,7 +8,7 @@
  */
 
 .global MeasureReadLatency
-// uint64_t MeasureReadLatency(const char* address);
+// uint64_t MeasureReadLatency(const void* address);
 MeasureReadLatency:
   // x0 = address
 

--- a/demos/asm/measurereadlatency_ppc64le.S
+++ b/demos/asm/measurereadlatency_ppc64le.S
@@ -8,7 +8,7 @@
  */
 
 .global MeasureReadLatency
-// uint64_t MeasureReadLatency(const char* address);
+// uint64_t MeasureReadLatency(const void* address);
 MeasureReadLatency:
   // r3 = address
 

--- a/demos/asm/measurereadlatency_x86.S
+++ b/demos/asm/measurereadlatency_x86.S
@@ -10,7 +10,7 @@
 .intel_syntax noprefix
 
 .global MeasureReadLatency
-// uint64_t MeasureReadLatency(const char* address);
+// uint64_t MeasureReadLatency(const void* address);
 //
 // See measurereadlatency_x86_64.S for more details on what this function does,
 // in particular for why MFENCEs and LFENCEs occur where they do. The only

--- a/demos/asm/measurereadlatency_x86_64.S
+++ b/demos/asm/measurereadlatency_x86_64.S
@@ -17,7 +17,7 @@
 .intel_syntax noprefix
 
 .global DECORATE(MeasureReadLatency)
-// uint64_t MeasureReadLatency(const char* address);
+// uint64_t MeasureReadLatency(const void* address);
 DECORATE(MeasureReadLatency):
   // rdi = address
 

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -62,9 +62,7 @@ std::pair<bool, char> CacheSideChannel::RecomputeScores(
     // them all equally fast. Therefore it is necessary to confuse them by
     // accessing the offsets in a pseudo-random order.
     size_t mixed_i = ((i * 167) + 13) & 0xFF;
-    const void *timing_entry = &GetOracle()[mixed_i];
-    latencies[mixed_i] = MeasureReadLatency(
-        static_cast<const char *>(timing_entry));
+    latencies[mixed_i] = MeasureReadLatency(&GetOracle()[mixed_i]);
   }
 
   std::list<uint64_t> sorted_latencies_list(latencies.begin(), latencies.end());

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -21,8 +21,7 @@ inline void ForceRead(const void *p) {
   (void)*reinterpret_cast<const volatile char *>(p);
 }
 
-// Flush a memory interval from cache. Used to induce speculative execution on
-// flushed values until they are fetched back to the cache.
-void FlushFromCache(const char *start, const char *end);
+// Flush [begin, end) from cache. No alignment is assumed.
+void FlushFromCache(const void *begin, const void *end);
 
 #endif  // DEMOS_UTILS_H_


### PR DESCRIPTION
Taking `char*` made it easier to do pointer arithmetic in the function but required casts on some callers.

Since I was focusing on pointer arithmetic anyway, rewrote `FlushFromCache` to be a bit more precise and flush each cache line exactly once.