### PR TITLE
Fix MSVC warnings about redundant `inline`

### DIFF
--- a/demos/compiler_specifics.h
+++ b/demos/compiler_specifics.h
@@ -26,6 +26,13 @@
 #ifdef _MSC_VER
 #define SAFESIDE_MSVC 1
 #define SAFESIDE_NEVER_INLINE __declspec(noinline)
+
+// If a function is modified by both `inline` and `SAFESIDE_ALWAYS_INLINE`,
+// MSVC may issue a diagnostic:
+//     warning C4141: 'inline': used more than once
+//
+// To avoid this, put `inline` *before* `SAFESIDE_ALWAYS_INLINE` on any
+// function that will be compiled by MSVC.
 #define SAFESIDE_ALWAYS_INLINE __forceinline
 #elif defined(__GNUC__)
 #define SAFESIDE_GNUC 1

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -38,8 +38,8 @@ void CLFlush(const void *memory);
 // Yields serializing instruction.
 // Must be inlined in order to avoid to avoid misprediction that skips the
 // call.
-SAFESIDE_ALWAYS_INLINE
-inline void MemoryAndSpeculationBarrier() {
+inline SAFESIDE_ALWAYS_INLINE
+void MemoryAndSpeculationBarrier() {
 #if SAFESIDE_X64 || SAFESIDE_IA32
 #  if SAFESIDE_MSVC
   int cpuinfo[4];

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -16,8 +16,8 @@
 // speculative execution to create a microarchitectural side effect in the
 // cache. Also used for latency measurement in the FLUSH+RELOAD technique.
 // Should be inlined to minimize the speculation window.
-SAFESIDE_ALWAYS_INLINE
-inline void ForceRead(const void *p) {
+inline SAFESIDE_ALWAYS_INLINE
+void ForceRead(const void *p) {
   (void)*reinterpret_cast<const volatile char *>(p);
 }
 


### PR DESCRIPTION
MSVC thinks `__forceinline inline` is redundant because `__forceinline`
implies `inline`. The opposite isn't true, so we avoid the warning by
reversing them on any declaration MSVC can see.