### PR TITLE
Create a header just for page + cache line sizes

### DIFF
--- a/demos/hardware_constants.h
+++ b/demos/hardware_constants.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_HARDWARE_CONSTANTS_H_
+#define DEMOS_HARDWARE_CONSTANTS_H_
+
+#include <cstddef>
+
+#include "compiler_specifics.h"
+
+// Constants describing properties of the current processor architecture.
+#if SAFESIDE_PPC
+constexpr size_t kCacheLineBytes = 128;
+constexpr size_t kPageBytes = 64 * 1024;
+#else
+constexpr size_t kCacheLineBytes = 64;
+constexpr size_t kPageBytes = 4 * 1024;
+#endif
+
+#endif  // DEMOS_HARDWARE_CONSTANTS_H_

--- a/demos/instr.h
+++ b/demos/instr.h
@@ -25,13 +25,6 @@
 #  endif
 #endif
 
-// Page size.
-#if SAFESIDE_PPC
-constexpr uint32_t kPageSizeBytes = 65536;
-#else
-constexpr uint32_t kPageSizeBytes = 4096;
-#endif
-
 // Flushing cacheline containing given address.
 void CLFlush(const void *memory);
 

--- a/demos/ret2spec_sa.cc
+++ b/demos/ret2spec_sa.cc
@@ -35,7 +35,6 @@
 // Recursion depth should be equal or greater than the RSB size, but not
 // excessively high because of the possibility of stack overflow.
 constexpr size_t kRecursionDepth = 64;
-constexpr size_t kCacheLineSize = 64;
 
 // Global variables used to avoid passing parameters through recursive function
 // calls. Since we flush whole stack frames from the cache, it is important not

--- a/demos/spectre_v1_btb_sa.cc
+++ b/demos/spectre_v1_btb_sa.cc
@@ -24,7 +24,6 @@
 const char *public_data = "xxxxxxxxxxxxxxxx";
 const char *private_data = "It's a s3kr3t!!!";
 constexpr size_t kAccessorArrayLength = 1024;
-constexpr size_t kCacheLineSize = 64;
 
 // DataAccessor provides an interface to access bytes from either the public or
 // the private storage.

--- a/demos/utils.cc
+++ b/demos/utils.cc
@@ -11,11 +11,10 @@
 
 #include <cstddef>
 
+#include "hardware_constants.h"
 #include "instr.h"
 
 namespace {
-
-constexpr size_t kCacheLineSize = 64;
 
 // Returns the address of the first byte of the cache line *after* the one on
 // which `addr` falls.
@@ -24,7 +23,7 @@ const void* StartOfNextCacheLine(const void* addr) {
 
   // Create an address on the next cache line, then mask it to round it down to
   // cache line alignment.
-  auto next_n = (addr_n + kCacheLineSize) & ~(kCacheLineSize - 1);
+  auto next_n = (addr_n + kCacheLineBytes) & ~(kCacheLineBytes - 1);
   return reinterpret_cast<const void*>(next_n);
 }
 


### PR DESCRIPTION
Break these out of `instr.h`, which comes with a lot of other stuff.

Remove some other redundant definitions that were mostly unused.