### PR TITLE
Refactor architecture-specific code

### DIFF
--- a/demos/asm/measurereadlatency_aarch64.S
+++ b/demos/asm/measurereadlatency_aarch64.S
@@ -12,26 +12,17 @@
 MeasureReadLatency:
   // x0 = address
 
-  // Serialize the instruction stream and finish all memory operations.
+  // Full memory and speculation barrier. See docs/fencing.md for details.
   //
-  // The data synchronization barrier (DSB, [1]) instruction waits for all
-  // memory and cache manipulation operations to finish before completing, and
-  // prevents *almost* all subsequent instructions from having any effect until
-  // the DSB completes.
-  //
-  // One exception to DSB's serialization effects is reads of the System
-  // registers that are done "without causing side-effects", which some
-  // platforms consider to include reading the virtual count.
-  //
-  // To avoiding the timestamp read passing older instructions, we also issue
-  // an Instruction Synchronization Barrier (ISB, [2]). ISB ensures that the
-  // effect of "context-changing operations", for example "changes to System
-  // registers", are visible to subsequent instructions.
+  // Of special note: we need the ISB here to prevent some processors from
+  // speculating ahead and reading the timestamp counter early. DSB doesn't
+  // stop later instructions from "[r]eading ... System registers that are
+  // directly or indirectly read without causing side-effects"[1], which seems
+  // to include the virtual count.
   //
   // Linux adds an ISB before reading CNTVCT_EL0: https://git.io/Jeivz
   //
   // [1] DSB: https://cpu.fyi/d/047#G9.10258412
-  // [2] ISB: https://cpu.fyi/d/047#G9.10257730
   dsb sy
   isb
 

--- a/demos/asm/measurereadlatency_ppc64le.S
+++ b/demos/asm/measurereadlatency_ppc64le.S
@@ -12,24 +12,7 @@
 MeasureReadLatency:
   // r3 = address
 
-  // Serialize the instruction stream and finish all memory operations.
-  //
-  // SYNC[1] waits for all preceding instructions to complete before any
-  // subsequent instructions are initiated. It also waits until *almost* all
-  // preceding memory operations have completed, with the exception of accesses
-  // caused by ICBI[2].
-  //
-  // To wait for these last accesses, we also issue an ISYNC[3] instruction.
-  // ISYNC has the same serializing effect on the instruction stream as SYNC,
-  // but doesn't enforce order of any memory accesses *except* those caused by
-  // a preceding ICBI.
-  //
-  // Of note, Linux uses `ISYNC; SYNC` as a speculation barrier on some PowerPC
-  // devices: https://git.io/Je60x
-  //
-  // [1] SYNC: https://cpu.fyi/d/a48#G19.1034642
-  // [2] ICBI: https://cpu.fyi/d/a48#G19.1020460
-  // [3] ISYNC: https://cpu.fyi/d/a48#G19.1020771
+  // Full memory and speculation barrier. See docs/fencing.md for details.
   isync
   sync
 

--- a/demos/asm/measurereadlatency_x86_64.S
+++ b/demos/asm/measurereadlatency_x86_64.S
@@ -21,32 +21,7 @@
 DECORATE(MeasureReadLatency):
   // rdi = address
 
-  // Serialize the instruction stream and finish all memory operations.
-  //
-  // LFENCE[1] waits for all prior instructions to complete[2] before allowing
-  // any later instructions to start, but (as the name would suggest) it
-  // doesn't wait for memory operations other than loads to complete. So we add
-  // an MFENCE[3], which is a full memory barrier but does not serialize the
-  // instruction stream, followed by an LFENCE. The LFENCE must come second so
-  // that it will wait for the MFENCE to complete.
-  //
-  // MFENCE also waits for prior CLFLUSH and CLFLUSHOPT instructions to finish
-  // before continuing.[4]
-  //
-  // See also: the FLUSH+RELOAD paper[5], specifically Figure 4 on page 5 and
-  // the accompanying explanation.
-  //
-  // [1] LFENCE: https://cpu.fyi/d/484#G5.136804
-  // [2] At least, on Intel processors. LFENCE is _not_ documented as
-  //   serializing on AMD processors (https://cpu.fyi/d/ad5#G9.3072402), but
-  //   in early 2018 AMD described a model-specific register (MSR) that system
-  //   software can set to make LFENCE serializing on all existing and future
-  //   AMD processors. (See https://cpu.fyi/l/AxzQB, page 3, "Mitigation G-2".)
-  //   This MSR has been set in Linux since v4.15: https://git.io/JePgI
-  // [3] MFENCE: https://cpu.fyi/d/484#G7.864843
-  // [4] "Memory Ordering in P6 and More Recent Processor Families":
-  //   https://cpu.fyi/d/749#G13.31870
-  // [5] FLUSH+RELOAD: https://eprint.iacr.org/2013/448.pdf
+  // Full memory and speculation barrier. See docs/fencing.md for details.
   mfence
   lfence
 
@@ -67,7 +42,7 @@ DECORATE(MeasureReadLatency):
   // Read *rdi.
   mov al, byte ptr [rdi]
 
-  // Finish the read before reading the timestamp again. Here, LFENCE suffices
+  // Finish the read before reading the timestamp again. LFENCE suffices here
   // because it serializes the instruction stream *and* waits for load
   // operations to complete.
   lfence

--- a/demos/cache_sidechannel.cc
+++ b/demos/cache_sidechannel.cc
@@ -39,8 +39,9 @@ void CacheSideChannel::FlushOracle() const {
   // speculative execution, that will warm the cache for that entry, which
   // can be detected later via timing analysis.
   for (BigByte &b : padded_oracle_array_->oracles_) {
-    CLFlush(&b);
+    FlushDataCacheLineNoBarrier(&b);
   }
+  MemoryAndSpeculationBarrier();
 }
 
 std::pair<bool, char> CacheSideChannel::RecomputeScores(

--- a/demos/instr.cc
+++ b/demos/instr.cc
@@ -28,25 +28,6 @@
 #  error Unsupported CPU.
 #endif  // SAFESIDE_IA32
 
-// Architecturally dependent cache flush.
-void CLFlush(const void *memory) {
-#if SAFESIDE_X64 || SAFESIDE_IA32
-  _mm_clflush(memory);
-  _mm_mfence();
-  _mm_lfence();
-#elif SAFESIDE_ARM64
-  asm volatile("dc civac, %0\n"
-               "dsb sy\n" ::"r"(memory)
-               : "memory");
-#elif SAFESIDE_PPC
-  asm volatile("dcbf 0, %0\n"
-               "sync" ::"r"(memory)
-               : "memory");
-#else
-#  error Unsupported CPU.
-#endif
-}
-
 #if SAFESIDE_GNUC
 SAFESIDE_NEVER_INLINE
 void UnwindStackAndSlowlyReturnTo(const void *address) {

--- a/demos/instr_aarch64.h
+++ b/demos/instr_aarch64.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_INSTR_AARCH64_H_
+#define DEMOS_INSTR_AARCH64_H_
+
+#include "compiler_specifics.h"
+
+inline SAFESIDE_ALWAYS_INLINE void MemoryAndSpeculationBarrier() {
+  // See docs/fencing.md
+  asm volatile(
+      "dsb sy\n"
+      "isb\n"
+      :
+      :
+      : "memory");
+}
+
+inline void FlushDataCacheLineNoBarrier(const void *address) {
+  // "data cache clean and invalidate by virtual address to point of coherency"
+  // https://cpu.fyi/d/047#G22.6241562
+  asm volatile(
+      "dc civac, %0\n"
+      :
+      : "r"(address)
+      : "memory");
+}
+
+#endif  // DEMOS_INSTR_AARCH64_H_

--- a/demos/instr_ppc64le.h
+++ b/demos/instr_ppc64le.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_INSTR_PPC64LE_H_
+#define DEMOS_INSTR_PPC64LE_H_
+
+#include "compiler_specifics.h"
+
+inline SAFESIDE_ALWAYS_INLINE void MemoryAndSpeculationBarrier() {
+  // See docs/fencing.md
+  asm volatile(
+      "isync\n"
+      "sync\n"
+      :
+      :
+      : "memory");
+}
+
+inline void FlushDataCacheLineNoBarrier(const void *address) {
+  // "data cache block flush" with L=0 to invalidate the cache block across all
+  // processors. https://cpu.fyi/d/a48#G19.1156482
+  asm volatile(
+      "dcbf 0, %0\n"
+      :
+      : "r"(address)
+      : "memory");
+}
+
+#endif  // DEMOS_INSTR_PPC64LE_H_

--- a/demos/instr_x86.h
+++ b/demos/instr_x86.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_INSTR_X86_H_
+#define DEMOS_INSTR_X86_H_
+
+#include "compiler_specifics.h"
+
+#if SAFESIDE_MSVC
+#  include <intrin.h>
+#else
+#  include <x86intrin.h>
+#endif
+
+// Implementations should stick to x86 intrinsics. Inline assembly has wildly
+// different syntax in GCC/Clang and MSVC/Win32, and isn't supported at all in
+// MSVC/x64.
+
+inline SAFESIDE_ALWAYS_INLINE void MemoryAndSpeculationBarrier() {
+  // See docs/fencing.md
+  _mm_mfence();
+  _mm_lfence();
+}
+
+inline void FlushDataCacheLineNoBarrier(const void *address) {
+  _mm_clflush(address);
+}
+
+#endif  // DEMOS_INSTR_X86_H_

--- a/demos/ret2spec_sa.cc
+++ b/demos/ret2spec_sa.cc
@@ -83,7 +83,7 @@ static bool ReturnsTrue(int counter) {
   // own stack mark and the next one. Somewhere there must be also the return
   // address.
   stack_mark_pointers.pop_back();
-  FlushFromCache(&stack_mark, stack_mark_pointers.back());
+  FlushFromDataCache(&stack_mark, stack_mark_pointers.back());
   return true;
 }
 

--- a/demos/spectre_v1_btb_ca.cc
+++ b/demos/spectre_v1_btb_ca.cc
@@ -114,7 +114,7 @@ static char LeakByte(size_t offset) {
 
       // Only the parent needs to flush the accessor.
       if (pid != 0) {
-        FlushFromCache(accessor_bytes, accessor_bytes + sizeof(DataAccessor));
+        FlushFromDataCache(accessor_bytes, accessor_bytes + sizeof(DataAccessor));
       }
 
       // Speculative fetch at the offset. Architecturally the victim fetches

--- a/demos/spectre_v1_btb_sa.cc
+++ b/demos/spectre_v1_btb_sa.cc
@@ -116,7 +116,7 @@ static char LeakByte(size_t offset) {
       // We make sure to flush whole accessor object in case it is
       // hypothetically on multiple cache-lines.
       const char *accessor_bytes = reinterpret_cast<const char*>(accessor);
-      FlushFromCache(accessor_bytes, accessor_bytes + object_size_in_bytes);
+      FlushFromDataCache(accessor_bytes, accessor_bytes + object_size_in_bytes);
 
       // Speculative fetch at the offset. Architecturally it fetches
       // always from the public_data, though speculatively it fetches the

--- a/demos/spectre_v1_pht_sa.cc
+++ b/demos/spectre_v1_pht_sa.cc
@@ -49,7 +49,7 @@ static char LeakByte(const char *data, size_t offset) {
     for (size_t i = 0; i < 2048; ++i) {
       // Remove from cache so that we block on loading it from memory,
       // triggering speculative execution.
-      CLFlush(size_in_heap.get());
+      FlushDataCacheLine(size_in_heap.get());
 
       // Train the branch predictor: perform in-bounds accesses 2047 times,
       // and then use the out-of-bounds offset we _actually_ care about on the

--- a/demos/spectre_v4.cc
+++ b/demos/spectre_v4.cc
@@ -68,8 +68,8 @@ static char LeakByte(const char *data, size_t offset) {
               i - local_pointer_index);
 
       // We always flush the pointer, so that its access is slower.
-      CLFlush(&(*array_of_pointers)[i]);
-      CLFlush(array_of_pointers.get());
+      FlushDataCacheLine(&(*array_of_pointers)[i]);
+      FlushDataCacheLine(array_of_pointers.get());
 
       // When i is at the local_pointer_index, we slowly copy safe_offset into
       // the local_offset. Otherwise we just copy the safe_offset to junk. After

--- a/demos/timing_array.cc
+++ b/demos/timing_array.cc
@@ -40,8 +40,11 @@ TimingArray::TimingArray() {
 void TimingArray::FlushFromCache() {
   // We only need to flush the cache lines with elements on them.
   for (int i = 0; i < size(); ++i) {
-    CLFlush(&ElementAt(i));
+    FlushDataCacheLineNoBarrier(&ElementAt(i));
   }
+
+  // Wait for flushes to finish.
+  MemoryAndSpeculationBarrier();
 }
 
 int TimingArray::FindFirstCachedElementIndexAfter(int start_after) {

--- a/demos/utils.cc
+++ b/demos/utils.cc
@@ -29,8 +29,9 @@ const void* StartOfNextCacheLine(const void* addr) {
 
 }  // namespace
 
-void FlushFromCache(const void *begin, const void *end) {
+void FlushFromDataCache(const void *begin, const void *end) {
   for (; begin < end; begin = StartOfNextCacheLine(begin)) {
-    CLFlush(begin);
+    FlushDataCacheLineNoBarrier(begin);
   }
+  MemoryAndSpeculationBarrier();
 }

--- a/demos/utils.h
+++ b/demos/utils.h
@@ -22,6 +22,6 @@ void ForceRead(const void *p) {
 }
 
 // Flush [begin, end) from cache. No alignment is assumed.
-void FlushFromCache(const void *begin, const void *end);
+void FlushFromDataCache(const void *begin, const void *end);
 
 #endif  // DEMOS_UTILS_H_

--- a/docs/fencing.md
+++ b/docs/fencing.md
@@ -1,0 +1,76 @@
+# Stopping the world
+
+This doc describes how we implement a complete memory and speculation barrier on various architectures. These barriers serialize the thread of execution by preventing any later instructions from starting until all previous instructions and all memory operations have entirely finished.
+
+The memory operations we want to wait for obviously include reads and writes, but also cache flushes.
+
+We need a barrier like this in a few places:
+- Preventing speculative execution from disturbing state we want to measure, e.g. the timing of a memory operation
+- Waiting for a cache flush to finish so we know a later read will bring one element _back_ into the cache.
+- Waiting for a change that changes the semantics of the whole instruction stream -- what ARM would call "context-changing operations" -- to take full effect before continuing even speculatively. An example is changing the alignment check (`AC`) bit in `EFLAGS` on x86.
+
+## Implementing on x86
+
+```assembly
+MFENCE
+LFENCE
+```
+
+The [load fence (`LFENCE`)](https://cpu.fyi/d/484#G5.136804) instruction serializes the instruction stream -- that is, it waits for all prior instructions to complete before allowing any later instructions to start.
+
+However, on x86 a store is considered "complete" when it _starts_ (enters the store buffer), not when it's _visible_. And, as the name suggests, `LFENCE` doesn't take special care to wait for stores to reach memory. In order to serialize _all_ memory operations we also need a [memory fence (`MFENCE`)](https://cpu.fyi/d/484#G7.864843), which  [waits](https://cpu.fyi/d/749#G13.31870) for all prior reads, writes, and `CLFLUSH` and `CLFLUSHOPT` instructions to be entirely finished before completing.
+
+The `LFENCE` has to come _after_ the `MFENCE` because only `LFENCE` serializes the instruction stream.
+
+### Caveat: `LFENCE` on AMD
+
+Technically, `LFENCE` is [_not_ documented as serializing the instruction stream](https://cpu.fyi/d/ad5#G9.3072402) on AMD processors. In early 2018 AMD described a model-specific register (MSR) that system software can set to make `LFENCE` serializing on all existing and future AMD processors. ([_Software techniques for managing speculation on AMD processors_](https://cpu.fyi/l/AxzQB), page 3, mitigation G-2.)
+
+This MSR [has been set in Linux](https://git.io/JePgI) since kernel version 4.15.
+
+### Other implementations
+
+Another option for an unprivileged, fully-serializing instruction is [`CPUID`](https://cpu.fyi/d/484#G5.876260). One reason to avoid `CPUID` is that it can cause an exit to the hypervisor when running in a virtual machine. Hosts use this to control which CPU features are discoverable in the guest VM, sometimes to present a homogenous level of functionality when VMs can be migrated across different hosts. The net result is that `CPUID` can be very slow with high variance.
+
+For the specific case of timing an instruction sequence, we could use [`RDTSCP`](https://cpu.fyi/d/484#G7.587245). Before reading from the timestamp counter, `RDTSCP` first waits for all previous instructions and loads from memory to finish. It does *not* stop later instructions from starting, so it can't be used to build a full barrier.
+
+### Other references
+
+- ["Serializing Instructions"](https://cpu.fyi/d/749#G13.8467) in the _Intel Software Developer's Manual_
+- [_FLUSH+RELOAD: a High Resolution, Low Noise, L3 Cache Side-Channel Attack_](https://eprint.iacr.org/2013/448.pdf), specifically Figure 4 on page 5 and the accompanying explanation.
+
+## Implementing on ARM64
+
+```assembly
+DSB SY
+ISB
+```
+
+The [data synchronization barrier (`DSB`)](https://cpu.fyi/d/047#G9.10258412) instruction waits for all memory accesses and "cache maintenance instructions" to finish before completing, and prevents instructions later in program order from beginning *almost* any work until the `DSB` completes.
+
+The two exceptions are:
+- Instructions can be fetched and decoded
+- Registers can be read "without causing side-effects"
+
+These might seem innocuous, but empirically we've seen the second item extends to registers we _want_ to wait to read, e.g. the timestamp counter.
+
+To build a complete barrier, we add the [instruction synchronization barrier (`ISB`)](https://cpu.fyi/d/047#G9.10257730) instruction. `ISB` ensures that all later instructions are fetched from memory and decoded after the `ISB` completes and that "context-changing operations" executed before the `ISB` are visible to instructions after.
+
+## Implementing on PowerPC
+
+```assembly
+ISYNC
+SYNC
+```
+
+The [synchronize (`SYNC`)](https://cpu.fyi/d/a48#G19.1034642) instruction waits for all preceding instructions to complete before any subsequent instructions are initiated. It also waits until _almost_ all preceding memory operations have completed, with the exception of those initiated by ["instruction cache block invalidate" (`ICBI`)](https://cpu.fyi/d/a48#G19.1020460), i.e. instruction cache flush.
+
+To wait for these last accesses, we also issue the [instruction synchronize (`ISYNC`)](https://cpu.fyi/d/a48#G19.1020771) instruction. `ISYNC` has the same serializing effect on the instruction stream as `SYNC`, but doesn't enforce order of any memory accesses *except* those caused by a preceding `ICBI`.
+
+It's not obvious if the ordering of these two instructions matters. [Linux uses `ISYNC; SYNC`](https://git.io/Je60x).
+
+## Other implementation notes
+
+The barrier must never be implemented as an indirect function call (e.g. `vtable` lookup or shared library export), since it's possible for the call itself to be mispredicted and for speculative execution to continue in an unintended direction.
+
+It's safest for implementations to always be inlined into the caller.

--- a/docs/fencing.md
+++ b/docs/fencing.md
@@ -50,7 +50,7 @@ The [data synchronization barrier (`DSB`)](https://cpu.fyi/d/047#G9.10258412) in
 
 The two exceptions are:
 - Instructions can be fetched and decoded
-- Registers can be read "without causing side-effects"
+- Registers that are read "without causing side-effects"
 
 These might seem innocuous, but empirically we've seen the second item extends to registers we _want_ to wait to read, e.g. the timestamp counter.
 
@@ -67,7 +67,7 @@ The [synchronize (`SYNC`)](https://cpu.fyi/d/a48#G19.1034642) instruction waits 
 
 To wait for these last accesses, we also issue the [instruction synchronize (`ISYNC`)](https://cpu.fyi/d/a48#G19.1020771) instruction. `ISYNC` has the same serializing effect on the instruction stream as `SYNC`, but doesn't enforce order of any memory accesses *except* those caused by a preceding `ICBI`.
 
-It's not obvious if the ordering of these two instructions matters. [Linux uses `ISYNC; SYNC`](https://git.io/Je60x).
+There's no obvious reason the order of these two instructions should matter. [Linux uses `ISYNC; SYNC`](https://git.io/Je60x).
 
 ## Other implementation notes
 


### PR DESCRIPTION
Move comments about implementing memory and speculation barriers into its own Markdown file and expand it a bit.

Put code specific to each architecture in its own header file.

Use `mfence; lfence` for a total barrier on x86 instead of `cpuid`. This is partly for the reasons in `docs/fencing.md` but also so we have one canonical instruction sequence everywhere we're using it.

Rename `CLFlush` to `FlushDataCacheLine` to avoid the x86-specific name. Add `FlushFromDataCacheLineNoBarrier` for places where we flush in a loop, since we can just have one serialization barrier at the end.