### PR TITLE
Show CPU info at start of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     - name: "Windows / MSVC / x64, Win32"
       os: windows
       # CMake picks up MSVC regardless of what compiler we specify here.
+before_script:
+  - ./ci/show-cpu-info
 script:
   - ./ci/build
   - ./ci/test

--- a/ci/show-cpu-info
+++ b/ci/show-cpu-info
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+cpuinfo_linux() {
+  which lscpu >/dev/null && lscpu
+}
+
+cpuinfo_mac() {
+  which sysctl >/dev/null && sysctl -a | grep '^machdep.cpu.'
+}
+
+cpuinfo_windows() {
+  which powershell >/dev/null && \
+      powershell -Command Get-WmiObject -Class Win32_Processor
+}
+
+cpuinfo_linux || cpuinfo_mac || cpuinfo_windows


### PR DESCRIPTION
When debugging the failures mentioned in #121, I wanted to see if any of the nodes were running an AMD CPU since we know their hardware prefetcher works differently. It seems like this information will be generically useful in the future and it's easy to collect.