### PR TITLE
Build kernel modules when sources change

### DIFF
--- a/kernel_modules/CMakeLists.txt
+++ b/kernel_modules/CMakeLists.txt
@@ -10,49 +10,31 @@ function(build_kernel_module MODULE_NAME)
     message(STATUS "Skipping kernel module in cross-compile build")
     return()
   endif()
+
   # Determine what kernel source tree we'll use to build the module.
   # CMAKE_HOST_SYSTEM_VERSION uses `uname -r` on Linux.
   # https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_VERSION.html
   set(KERNEL_SRC "/lib/modules/${CMAKE_HOST_SYSTEM_VERSION}/build")
-
   if(EXISTS "${KERNEL_SRC}")
     message(STATUS "Kernel build directory: ${KERNEL_SRC}")
   else()
     message(FATAL_ERROR
-        " Can't find headers to build Meltdown kernel module.\n"
+        " Can't find headers to build kernel modules.\n"
         " Try:\n"
         "     sudo apt install linux-headers-${CMAKE_HOST_SYSTEM_VERSION}"
     )
   endif()
 
-  # Move the inputs into a directory in the output first. Kbuild seems to use
-  # KBUILD_EXTMOD to set both the source of the out-of-tree kernel module to
-  # build *and* the build output directory, so we can't build from the source
-  # tree while putting outputs somewhere else.
+  # Create the directory where we'll invoke Kbuild to compile the module.
+  #
+  # So far as we can tell, Kbuild uses KBUILD_EXTMOD to set *both* the source
+  # for the out-of-tree kernel module *and* the build output directory, so we
+  # can't build directly from the source tree while putting outputs elsewhere.
+  #
+  # To avoid cluttering the tree, we *copy* Makefile and <module>.c into the
+  # output directory and let Kbuild find them there.
   set(MODULE_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${MODULE_NAME})
   file(MAKE_DIRECTORY ${MODULE_OUTPUT_DIR})
-  file(COPY Makefile ${MODULE_NAME}.c DESTINATION ${MODULE_OUTPUT_DIR})
-
-  # Invoke the kernel Makefile (kbuild) to build the kernel module.
-  # https://www.kernel.org/doc/Documentation/kbuild/modules.txt
-  add_custom_command(
-      OUTPUT ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko
-      COMMAND make
-          -C ${KERNEL_SRC}
-          KBUILD_EXTMOD=${MODULE_OUTPUT_DIR}
-          modules
-      DEPENDS
-          ${MODULE_OUTPUT_DIR}/Makefile
-          ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.c
-      VERBATIM
-  )
-
-  # Create a target to run the custom command.
-  add_custom_target(
-      ${MODULE_NAME}
-      ALL
-      DEPENDS ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko
-  )
 
   # Get a friendly relative path to the kernel module.
   file(
@@ -62,20 +44,47 @@ function(build_kernel_module MODULE_NAME)
       ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko
   )
 
-  # After building, show help for installing the kernel module.
+  # Create the actual build rule for the kernel module target.
   add_custom_command(
-      TARGET ${MODULE_NAME}
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      ARGS
-          -E cmake_echo_color
+      OUTPUT ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko
+
+      # Copy the Makefile and module implementation into the output directory.
+      #
+      # We do this here instead of using FILE(COPY ...) above because the FILE
+      # command only executes once at configuration time, and won't update
+      # these copies when the originals change.
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          ${CMAKE_CURRENT_SOURCE_DIR}/Makefile
+          ${CMAKE_CURRENT_SOURCE_DIR}/${MODULE_NAME}.c
+          ${MODULE_OUTPUT_DIR}
+
+      # Invoke Kbuild to build the module in the output directory.
+      # https://www.kernel.org/doc/Documentation/kbuild/modules.txt
+      COMMAND make
+          -C ${KERNEL_SRC}
+          KBUILD_EXTMOD=${MODULE_OUTPUT_DIR}
+          modules
+
+      # Show help for installing the newly-built module.
+      COMMAND ${CMAKE_COMMAND} -E cmake_echo_color
           ""
           --green --bold
-          "To install the Meltdown kernel module, run:"
+          "To install the kernel module, run:"
           --normal
           "    sudo insmod ${MODULE_RELATIVE_PATH}"
           ""
+
+      DEPENDS
+          Makefile
+          ${MODULE_NAME}.c
       VERBATIM
+  )
+
+  # Create a target to serve as a friendly name for the output module.
+  add_custom_target(
+      ${MODULE_NAME}
+      ALL
+      DEPENDS ${MODULE_OUTPUT_DIR}/${MODULE_NAME}.ko
   )
 endfunction(build_kernel_module)
 


### PR DESCRIPTION
Previously the files were only snapshotted once during configure.

Remove some incorrectly specific references to the "Meltdown" kernel module.

Tweak some spacing for readability.