### PR TITLE
Rewrite Meltdown module to use debugfs

### DIFF
--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -42,8 +42,9 @@ static char LeakByte(const char *data, size_t offset) {
   const std::array<BigByte, 256> &oracle = sidechannel.GetOracle();
 
   for (int run = 0;; ++run) {
-    // Load the kernel memory into the cache to speed up its leakage.
-    std::ifstream is("/proc/safeside_meltdown/length");
+    // Load the secret data into cache so it is more likely to be available
+    // to transient instructions.
+    std::ifstream is("/sys/kernel/debug/safeside_meltdown/secret_data_in_cache");
     is.get();
     is.close();
 
@@ -77,7 +78,7 @@ static char LeakByte(const char *data, size_t offset) {
 
 int main() {
   size_t private_data, private_length;
-  std::ifstream in("/proc/safeside_meltdown/address");
+  std::ifstream in("/sys/kernel/debug/safeside_meltdown/secret_data_address");
   if (in.fail()) {
     std::cerr << "Meltdown module not loaded or not running as root."
               << std::endl;
@@ -86,7 +87,7 @@ int main() {
   in >> std::hex >> private_data;
   in.close();
 
-  in.open("/proc/safeside_meltdown/length");
+  in.open("/sys/kernel/debug/safeside_meltdown/secret_data_length");
   in >> std::dec >> private_length;
   in.close();
 

--- a/kernel_modules/kmod_meltdown/meltdown_module.c
+++ b/kernel_modules/kmod_meltdown/meltdown_module.c
@@ -7,96 +7,98 @@
  * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
  */
 
+#include <linux/debugfs.h>
 #include <linux/module.h>
-#include <linux/proc_fs.h>
-#include <linux/seq_file.h>
 
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_AUTHOR("Google");
 MODULE_DESCRIPTION("");
-MODULE_VERSION("0.1");
+MODULE_VERSION("0.2");
 
-// Keeps a buffer in kernel memory and makes its address available at:
-//   /proc/safeside_meltdown/address
-// and its length available at:
-//   /proc/safeside_meltdown/length
-// which are both only accessible to root.
+// This module provides the kernel side of a test for Meltdown.
+//
+// It holds a buffer of "secret" data in kernel memory that is never made
+// (legitimately) available to userspace. Through debugfs, userspace can find
+// the address and length of that buffer and can force it to be read into
+// cache.
+//
+// Assuming debugfs is mounted in the usual place, the files are at:
+//   /sys/kernel/debug/safeside_meltdown/
+// And they are:
+//   secret_data_address
+//     virtual address of secret data, returned as "0x123"
+//   secret_data_length
+//     length of secret data in bytes, returned as "123"
+//   secret_data_in_cache
+//     when opened and read, forces secret data to be read into cache.
+//
+// Access is restricted to root to avoid opening any new attack surface, e.g.
+// leaking kernel pointers.
 
-// Secret data stored in the kernel memory whose content is never directly
-// leaked through sysfs.
-const char *private_data = "It's a s3kr3t!!!";
+// The notionally secret data.
+static const char secret_data[] = "It's a s3kr3t!!!";;
 
-// Directory record. Must be available on unloading the module.
-struct proc_dir_entry *safeside_meltdown;
+// Values published through debugfs.
+static u64 secret_data_address = (u64)secret_data;
+static u32 secret_data_length = sizeof(secret_data);
 
-// Print the address of `private_data` into the provided buffer.
-static int address_show(struct seq_file *file, void *v) {
-  seq_printf(file, "%px\n", private_data);
+// The dentry of our debugfs folder.
+static struct dentry *debugfs_dir = NULL;
+
+// Getter that reads secret_data into cache.
+// Userspace will read "1", a sort of arbitrary value that could be taken to
+// mean "yes, the secret data _is_ (now) in cache".
+static int secret_data_in_cache_get(void* data, u64* out) {
+  int i;
+  volatile const char *volatile_secret_data = secret_data;
+  for (i = 0; i < secret_data_length; ++i) {
+    (void)volatile_secret_data[i];
+  }
+
+  *out = 1;
   return 0;
 }
-
-// Print the length of `private_data` into the sequential file.
-// At the same time loads `private_data` to cache by accessing it.
-static int length_show(struct seq_file *file, void *v) {
-  seq_printf(file, "%d\n", (int) strlen(private_data));
-  return 0;
-}
-
-static int address_open(struct inode *i, struct file *file) {
-  return single_open(file, address_show, NULL);
-}
-
-static int length_open(struct inode *i, struct file *file) {
-  return single_open(file, length_show, NULL);
-}
-
-static struct file_operations address_file_ops = {
-  .open = address_open,
-  .read = seq_read,
-  .llseek = seq_lseek,
-  .release = single_release,
-};
-
-static struct file_operations length_file_ops = {
-  .open = length_open,
-  .read = seq_read,
-  .llseek = seq_lseek,
-  .release = single_release,
-};
+DEFINE_DEBUGFS_ATTRIBUTE(fops_secret_data_in_cache, secret_data_in_cache_get,
+    NULL, "%lld");
 
 static int __init meltdown_init(void) {
-  struct proc_dir_entry *address, *length;
+  struct dentry *child = NULL;
 
-  pr_info("safeside_meltdown init\n");
-
-  safeside_meltdown = proc_mkdir("safeside_meltdown", NULL);
-  if (safeside_meltdown == NULL) {
-    return -ENOMEM;
+  debugfs_dir = debugfs_create_dir("safeside_meltdown", /*parent=*/NULL);
+  if (!debugfs_dir) {
+    goto out_remove;
   }
 
-  // Read-only files, accessible only by root.
-  address = proc_create("address", 0400, safeside_meltdown, &address_file_ops);
-  if (address == NULL) {
-    remove_proc_entry("safeside_meltdown", NULL);
-    return -ENOMEM;
+  child = debugfs_create_u32("secret_data_length", 0400, debugfs_dir,
+      &secret_data_length);
+  if (!child) {
+    goto out_remove;
   }
 
-  length = proc_create("length", 0400, safeside_meltdown, &length_file_ops);
-  if (length == NULL) {
-    remove_proc_entry("address", safeside_meltdown);
-    remove_proc_entry("safeside_meltdown", NULL);
-    return -ENOMEM;
+  child = debugfs_create_x64("secret_data_address", 0400, debugfs_dir,
+      &secret_data_address);
+  if (!child) {
+    goto out_remove;
+  }
+
+  child = debugfs_create_file("secret_data_in_cache", 0400, debugfs_dir, NULL,
+      &fops_secret_data_in_cache);
+  if (!child) {
+    goto out_remove;
   }
 
   return 0;
+
+out_remove:
+  debugfs_remove_recursive(debugfs_dir);  /* benign on NULL */
+  debugfs_dir = NULL;
+
+  return -ENODEV;
 }
 
 static void __exit meltdown_exit(void) {
-  pr_info("safeside_meltdown exit\n");
-
-  remove_proc_entry("length", safeside_meltdown);
-  remove_proc_entry("address", safeside_meltdown);
-  remove_proc_entry("safeside_meltdown", NULL);
+  debugfs_remove_recursive(debugfs_dir);
+  debugfs_dir = NULL;
 }
 
 module_init(meltdown_init);


### PR DESCRIPTION
Part of addressing #108, and does actually turn out to be easier.

Adjust paths in `meltdown.cc` to match.