### PR TITLE
Add a new RunWithFaultHandler utility

### DIFF
--- a/ci/test
+++ b/ci/test
@@ -38,3 +38,4 @@ run_test() {
 
 run_test timing_array_test
 run_test spectre_v1_pht_sa
+run_test faults_test

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -50,6 +50,10 @@ add_library(safeside
     utils.cc
 )
 
+if(UNIX)
+  target_sources(safeside PRIVATE faults.cc)
+endif()
+
 # Configure the assembler. Set ASM_EXT (extension for assembly files) and
 # ASM_PLATFORM (target CPU), which we'll use to add the right assembly
 # implementation.
@@ -95,6 +99,11 @@ target_sources(
 
 add_executable(timing_array_test timing_array_test.cc)
 target_link_libraries(timing_array_test safeside)
+
+if(UNIX)
+  add_executable(faults_test faults_test.cc)
+  target_link_libraries(faults_test safeside)
+endif()
 
 # Defines an executable target named `demo_name` built from `demo_name.cc` and
 # linked against the Safeside support library. The caller can also use the

--- a/demos/faults.cc
+++ b/demos/faults.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#include "faults.h"
+
+#include <setjmp.h>
+
+#include <cstring>
+
+namespace {
+
+// The sigjmp context we should jump to after catching the fault.
+sigjmp_buf signal_handler_jmpbuf;
+
+extern "C"
+void SignalHandler(int signal, siginfo_t *info, void *ucontext) {
+  siglongjmp(signal_handler_jmpbuf, 1);
+}
+
+}  // namespace
+
+bool RunWithFaultHandler(std::function<void()> inner) {
+  struct sigaction sa = {};
+  sa.sa_sigaction = SignalHandler;
+
+  struct sigaction oldsa;
+  // This sets the signal handler for the entire process.
+  sigaction(SIGSEGV, &sa, &oldsa);
+
+  // Use sigsetjmp/siglongjmp to save and restore signal mask. Otherwise we
+  // will jump out of the signal handler and leave the currently-being-handled
+  // signal blocked. The result of a SIGSEGV being raised while blocked is
+  // "undefined"[1], but in practice leads to killing the process.
+  //
+  // [1] https://www.man7.org/linux/man-pages/man2/sigprocmask.2.html#NOTES
+  bool handled_fault = true;
+  if (sigsetjmp(signal_handler_jmpbuf, 1) == 0) {
+    inner();
+    handled_fault = false;
+  }
+
+  sigaction(SIGSEGV, &oldsa, nullptr);
+
+  return handled_fault;
+}

--- a/demos/faults.h
+++ b/demos/faults.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#ifndef DEMOS_FAULTS_H_
+#define DEMOS_FAULTS_H_
+
+#include <signal.h>
+
+#include <functional>
+
+// Run `inner` with a signal handler installed to catch failure signals,
+// currently defined as `SIGSEGV`. If such a signal is raised, the execution
+// of `inner` is aborted.
+//
+// Not thread-safe. Don't use from more than one thread at a time.
+//
+// Returns true iff a signal was handled.
+bool RunWithFaultHandler(std::function<void()> inner);
+
+#endif  // DEMOS_FAULTS_H_

--- a/demos/faults_test.cc
+++ b/demos/faults_test.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+ * LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+ */
+
+#include "faults.h"
+
+#include <iostream>
+
+// Tests that a SIGSEGV is successfully caught and the handler runs.
+bool TestHandlesSigsegv() {
+  bool pass = true;
+
+  bool ran_body = false;
+  bool saw_fault = RunWithFaultHandler([&]() {
+    ran_body = true;
+    raise(SIGSEGV);
+  });
+
+  if (!ran_body) {
+    std::cerr << "Didn't run expected function" << std::endl;
+    pass = false;
+  }
+  if (!saw_fault) {
+    std::cerr << "Didn't see expected fault" << std::endl;
+    pass = false;
+  }
+
+  return pass;
+}
+
+// Test that the handler doesn't run when no fault occurs.
+bool TestNoFault() {
+  bool pass = true;
+
+  bool ran_body = false;
+  bool saw_fault = RunWithFaultHandler([&]() {
+    ran_body = true;
+  });
+
+  if (!ran_body) {
+    std::cerr << "Didn't run expected function" << std::endl;
+    pass = false;
+  }
+  if (saw_fault) {
+    std::cerr << "Saw unexpected fault" << std::endl;
+    pass = false;
+  }
+
+  return pass;
+}
+
+int main(int argc, char* argv[]) {
+  bool pass = true;
+
+  // Run this test twice to check we reset signal masks correctly.
+  pass = pass && TestHandlesSigsegv();
+  pass = pass && TestHandlesSigsegv();
+
+  pass = pass && TestNoFault();
+
+  std::cout << (pass ? "pass" : "fail") << std::endl;
+
+  return !pass;
+}

--- a/demos/meltdown.cc
+++ b/demos/meltdown.cc
@@ -22,9 +22,8 @@
 #include <fstream>
 #include <iostream>
 
-#include <signal.h>
-
 #include "cache_sidechannel.h"
+#include "faults.h"
 #include "instr.h"
 #include "local_content.h"
 #include "meltdown_local_content.h"
@@ -54,14 +53,19 @@ static char LeakByte(const char *data, size_t offset) {
     // value of the in-bounds access is usually different from the secret value
     // we want to leak via out-of-bounds speculative access.
     size_t safe_offset = run % strlen(public_data);
-    ForceRead(oracle.data() + static_cast<size_t>(data[safe_offset]));
 
-    // Access attempt to the kernel memory. This does not succeed
-    // architecturally and kernel sends SIGSEGV instead.
-    ForceRead(oracle.data() + static_cast<size_t>(data[offset]));
+    bool handled_fault = RunWithFaultHandler([&]() {
+      ForceRead(oracle.data() + static_cast<size_t>(data[safe_offset]));
 
-    // SIGSEGV signal handler moves the instruction pointer to this label.
-    asm volatile("afterspeculation:");
+      // Access attempt to the kernel memory. This does not succeed
+      // architecturally and kernel sends SIGSEGV instead.
+      ForceRead(oracle.data() + static_cast<size_t>(data[offset]));
+    });
+
+    if (!handled_fault) {
+      std::cerr << "Read didn't yield expected fault" << std::endl;
+      exit(EXIT_FAILURE);
+    }
 
     std::pair<bool, char> result =
         sidechannel.RecomputeScores(data[safe_offset]);
@@ -91,7 +95,6 @@ int main() {
   in >> std::dec >> private_length;
   in.close();
 
-  OnSignalMoveRipToAfterspeculation(SIGSEGV);
   std::cout << "Leaking the string: ";
   std::cout.flush();
   const size_t private_offset =


### PR DESCRIPTION
This avoids the need for a global `afterspeculation` label.

Use to rewrite the Meltdown example.