### PR TITLE
[benchmarks] Add array access microbenchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,10 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(safeside VERSION 0.1.0 LANGUAGES C CXX)
 
+# Use C++11 without extensions
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS off)
+
+add_subdirectory(benchmarks)
 add_subdirectory(demos)
 add_subdirectory(kernel_modules)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(spectre_v1)

--- a/benchmarks/spectre_v1/CMakeLists.txt
+++ b/benchmarks/spectre_v1/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(unmitigated microbenchmark.cc)
+# Compile with -O0 so the array manipulation doesn't get optimized away by the
+# compiler.
+# FIXME: Replace this with tricks like this:
+# https://github.com/travisdowns/zero-fill-bench/blob/c30d8fc88d3f560ba165ef756167a2a703678134/opt-control.hpp#L11-L36
+target_compile_options(unmitigated PUBLIC -O0)
+
+# Speculative load hardening is only available in Clang >= 8.0.0.
+# Avoid VERSION_GREATER_EQUAL so we work with CMake < 3.7.
+if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") AND
+    (NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "8.0.0"))
+  add_executable(slh_mitigated microbenchmark.cc)
+  # Compile with -O0 so the array manipulation doesn't get optimized away by the
+  # compiler.
+  target_compile_options(slh_mitigated PUBLIC -mspeculative-load-hardening -O0)
+endif()

--- a/benchmarks/spectre_v1/README.md
+++ b/benchmarks/spectre_v1/README.md
@@ -1,0 +1,38 @@
+# Benchmarks of Spectre v1 Mitigations
+
+This folder has microbenchmarks to see the differences between the performance
+of Spectre v1 mitigations at a small scale.
+
+Microbenchmarks often do not reflect the performance costs of a mitigation in
+context, but they are useful for discussion when the limitations of
+microbenchmarks are considered along with the results.
+
+## Build instructions
+
+```
+$ bash
+$ cd safeside
+$ cmake -B build .
+$ make -C build
+
+# Everything should be built now.
+
+# Run the microbenchmark with no mitigation enabled.
+$ ./build/benchmarks/spectre_v1/unmitigated
+84733
+
+# If your compiler is Clang (>8.0.0), then this is also built.
+# Run the microbenchmark with speculative load hardening enabled.
+./build/benchmarks/spectre_v1/slh_mitigated
+193599
+
+# If you want to explicitly set your compiler to clang.
+
+$ CC=clang CXX=clang++ cmake -B build .
+
+# On systems like Ubuntu 18.04 where the system installed Clang's version is too
+# out of date to build slh_mitigated.
+$ sudo apt install clang-10
+$ CC=clang-10 CXX=clang++-10 cmake -B build .
+
+```

--- a/benchmarks/spectre_v1/microbenchmark.cc
+++ b/benchmarks/spectre_v1/microbenchmark.cc
@@ -1,0 +1,38 @@
+/**
+Copyright 2020 Google LLC
+
+Licensed under both the 3-Clause BSD License and the GPLv2, found in the
+LICENSE and LICENSE.GPL-2.0 files, respectively, in the root directory.
+
+SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+**/
+
+#include <chrono>
+#include <iostream>
+// This is a microbenchmark that can be used to compare the performance costs of
+// different Spectre variant 1 mitigations.
+//
+// This benchmark attempts to access an array 999 times with an in bounds index
+// and then once with an out of bounds index. This is repeated ten times. The
+// goal is to train the branch predictor to always take true branch, then to
+// cause speculative execution with the 1000th access with an out of bounds
+// index. The benchmark measures the total time taken for all of the iterations.
+int main() {
+  constexpr int kArrLen = 999;
+  int arr[kArrLen];
+  for (int i = 0; i < kArrLen; i++) {
+    arr[i] = 1;
+  }
+
+  int sum = 0;
+  auto start = std::chrono::system_clock::now();
+  for (int i = 0; i < 10000; i++) {
+    int j = i % 1000;
+    if (j < kArrLen) {
+      sum += arr[j];
+    }
+  }
+  auto end = std::chrono::system_clock::now();
+  auto elapsed = end - start;
+  std::cout << elapsed.count() << std::endl;
+}

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,7 +1,3 @@
-# Use C++11 without extensions
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS off)
-
 # Enable (or at least don't disable) some optimizations in all builds.
 # Without optimizations, it can be difficult to fit enough useful code into the
 # speculative execution window.


### PR DESCRIPTION
I'd like to start adding microbenchmarks that folks can run to compare the
effects Spectre v1 mitigations have on performance.

To start off with, I wrote a snippet of code that accesses an array 9990 times
with in bounds indices and 10 times with out of bounds indices. The goal was to
train the branch predictor with the 999 in bounds accesses, so that the out of
bounds access would be incorrectly predicted. I'm not 100% sure this is an
effective strategy to do that, so let me know if you think there is a better
way.

The build creates two versions: a version with no Spectre v1 mitigation and a
version with the Speculative Load Hardening (SLH) mitigation enabled.
(http://llvm.org/docs/SpeculativeLoadHardening.html)

The numbers I get from the unmitigated version on my machine are around 83,000
for the unmitigated version and 193,000 for the mitigated version which is
expected since SLH is known to have a high performance impact.

Microbenchmarks can't give the full picture of performance impact of mitigations
since they are out of context by definition. However, I think it's useful to
have the data available for discussion. System level benchmarks can come later.

Future plans (anyone can contribute if they'd like):
* Test any other existing Spectre v1 mitigations (__builtin_speculation_safe_value,
  fbl_confine_array/array_index_nospec, etc)
* Provide some data in SafeSide from a particular test environment that folks
  can reference if they don't want to get numbers themselves
* More microbenchmarks for Spectre v1 variants (Misspredicted switches, virtual
  function call missprediction)