### PR TITLE
Include <cstdint> header in timing_array.h

### DIFF
--- a/demos/timing_array.h
+++ b/demos/timing_array.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "hardware_constants.h"


### PR DESCRIPTION
This fixes a build issue on my machine (Linux, building with Clang / Clang++)