### PR TITLE
Update to Focal; enable build parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ branches:
   only:
     - main
 language: cpp
-dist: bionic
+dist: focal
 matrix:
   include:
     - name: "Linux / clang / x86_64"

--- a/ci/build
+++ b/ci/build
@@ -11,8 +11,8 @@ generate_and_build() {
   shift
 
   mkdir "${folder_name}"
-  (cd "${folder_name}"; cmake "$@" ..)
-  cmake --build "${folder_name}"
+  cmake "$@" -B "${folder_name}" .
+  cmake --build "${folder_name}" --parallel
 }
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then

--- a/ci/build
+++ b/ci/build
@@ -41,8 +41,8 @@ case "${OS_COMPILER_CPU}" in
     # Install the 32-bit compiler and C/C++ runtimes
     sudo apt install \
         g++-i686-linux-gnu \
-        libc6:i386 \
-        libstdc++6:i386
+        libc6-i386 \
+        lib32stdc++6
 
     generate_and_build build-x86_64
     generate_and_build build-i686 \


### PR DESCRIPTION
Updating to Ubuntu 20.04 (Focal) gets us a newer version of CMake that supports `--parallel`.

The most significant effect on build times is on `arm64`, where we went from 90 seconds to 50.