### PR TITLE
WIP: Continue running ppc64le and aarch64 on Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ branches:
   only:
     - main
 language: cpp
-dist: focal
+dist: bionic
 matrix:
   include:
     - name: "Linux / clang / x86_64"


### PR DESCRIPTION
Setting these to Focal has the neat effect of forcing the builds to run on x86 instead.