### PR TITLE
Use apt-get instead of apt to suppress warnings.

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -18,12 +18,12 @@ generate_and_build() {
 if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
   # Update package lists first. Without this, we've seen missing packages
   # and dependency conflicts that block installation.
-  sudo apt update
+  sudo apt-get update
 
   # Try to install kernel headers. Continue on failure, e.g. when running in
   # an LXD container where Ubuntu has no headers package corresponding to the
   # host kernel. In that case the kernel modules won't be built.
-  sudo apt install "linux-headers-$(uname -r)" || true
+  sudo apt-get install "linux-headers-$(uname -r)" || true
 fi
 
 OS_COMPILER_CPU=${TRAVIS_OS_NAME}_${TRAVIS_COMPILER}_${TRAVIS_CPU_ARCH}
@@ -39,7 +39,7 @@ case "${OS_COMPILER_CPU}" in
 
   linux_gcc_amd64)
     # Install the 32-bit compiler and C/C++ runtimes
-    sudo apt install \
+    sudo apt-get install \
         g++-i686-linux-gnu \
         libc6-i386 \
         lib32stdc++6


### PR DESCRIPTION
Apparently apt is meant for interactive use, and apt-get for script use. In theory apt allows itself to break backwards compatibility arbitrarily badly, making it a poor choice for scripting use, although atm the only difference is in output format and one default flag value for apt-get upgrade. We don't use apt-get upgrade and the output looks pretty much the same to me (travis doesn't record the progress bar and I'm not seeing the alleged color support), so there's no downsides to suppressing the warning by using apt-get. :)