### PR TITLE
More clearly define randomness in timing_array.h

### DIFF
--- a/demos/timing_array.h
+++ b/demos/timing_array.h
@@ -79,11 +79,21 @@ class TimingArray {
     // Map index to element.
     //
     // As mentioned in the class comment, we try to frustrate hardware
-    // prefetchers by applying a permutation so elements don't appear in memory
-    // in index order. The mapping is pretty simple: we multiply by an odd
-    // number and mod by 256. Any odd number 1<n<256 will cover the range, but
-    // we choose one that generates a sufficiently "random-looking" sequence.
-    // We also add an offset so that the first element isn't first in memory.
+    // prefetchers by applying a permutation so elements don't appear in
+    // memory in index order. We do this by using a Linear Congruential
+    // Generator (LCG) where the size of the array is the modulus.
+    // To guarantee that this is a permutation, we just need to follow the
+    // requirements here:
+    //
+    // https://en.wikipedia.org/wiki/Linear_congruential_generator#c_%E2%89%A0_0
+    //
+    // In this case, 113 makes a good choice: 113 is prime, 113-1 = 112 is
+    // divisible by 256's only prime factor (2), both are divisible by 4.
+    // If the array were dynamically sized, we would not be able to hardcode
+    // 113, and it would be difficult to produce a good multiplier.
+    // It may be desirable, instead, to switch to a different PRNG
+    // that also supports small periods and efficient seeking.
+    // (For example, a Permuted Congruential Generator.)
     static_assert(kRealElements == 256, "consider changing 113");
     size_t el = (100 + i*113) % kRealElements;
 


### PR DESCRIPTION
This is a Linear Congruential Generator. See e.g. https://en.cppreference.com/w/cpp/numeric/random/linear_congruential_engine and compare the formula ;)  i.e. we're basically reimplementing `std::linear_congruential_engine<113, 100, 256>`

This is an important observation, because it implies further restrictions on the number 113 -- it shouldn't just be odd, but in fact *prime* (or at least co-prime with the modulus), and 112 needs to satisfy several tests (in particular, divisible by 2 and 4, but ideally not 8 or 16 or so on). This also informs us how we can extend this to arbitrary sizes rather than 256.

The most obvious next step, if we want to reuse this for non-256-sized arrays, is to make it a PCG over the next-biggest sized power of 2 (and step the PCG until an in-range value is found). Alternatively, any other PRNG that supports O(1) seek and can have its period set arbitrarily small would suffice.

I'm not sure what these are called in computer science -- in math, it's just called a permutation. As in, I want a permutation over the integers 0..n -- a bijection from 0..n to 0..n. But if I google for permutation functions, I get algorithms for shuffling vectors instead of int->int permutations. :/