### PR TITLE
Replace shuffled vector with an LCG-based shuffled access pattern.

### DIFF
--- a/experimental/cache_size.cc
+++ b/experimental/cache_size.cc
@@ -21,7 +21,7 @@ int CacheSizeAnalysis() {
     // analyzes a range of memory sizes to find the maximum time needed to read
     // each of their elements
     for (int64_t size = kMinSize; size <= kMaxSize; size *= 1.5) {
-      fprintf(f, "%d, %lu\n", sz, FindMaxReadingTime(sz));
+      fprintf(f, "%d, %lu\n", size, FindMaxReadingTime(size));
       std::cout << ".";
       std::flush(std::cout);
     }

--- a/experimental/cache_size.h
+++ b/experimental/cache_size.h
@@ -27,13 +27,13 @@ inline unsigned char PermuteChar(unsigned char x) {
 inline uint32_t PermuteInt(uint32_t x, uint32_t max) {
   int num_bytes;
   if (max <= 1<<8) {
-      num_bytes = 1;
+    num_bytes = 1;
   } else if (max <= 1 << 16) {
-      num_bytes = 2;
+    num_bytes = 2;
   } else if (max <= 1 << 24) {
-      num_bytes = 3;
+    num_bytes = 3;
   } else {
-      num_bytes = 4;
+    num_bytes = 4;
   }
 
   unsigned char* begin_inclusive = reinterpret_cast<unsigned char*>(&x);
@@ -43,7 +43,7 @@ inline uint32_t PermuteInt(uint32_t x, uint32_t max) {
     // This will only execute more than once for the last byte, and only if max
     // isn't exactly 1 << (n*8).
     do {
-        *c = PermuteChar(*c);
+      *c = PermuteChar(*c);
     } while (x >= max);
   }
   return x;
@@ -59,7 +59,7 @@ template <typename T> class ShuffledSpan {
   ShuffledSpan& operator=(ShuffledSpan&&) = default;
 
   size_t size() const {
-      return size_;
+    return size_;
   }
 
   const T& operator[](size_t i) const {

--- a/experimental/cache_size.h
+++ b/experimental/cache_size.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <assert.h>
 
 // TODO: depending on in which directory the file end up these might need to be
 // changed
@@ -13,19 +14,63 @@
 #include "../demos/instr.h"
 #include "../demos/utils.h"
 
-// Returns a shuffled vector of integers from 0 (inclusive) to n (exclusive).
-// This can be used to randomize access order.
-inline std::vector<size_t> ShuffledRange(size_t n) {
-  std::vector<size_t> numbers;
-  numbers.reserve(n);
-  for (size_t i = 0; i < n; ++i) {
-    numbers.push_back(i);
-  }
-  std::random_device rd;
-  std::mt19937 f(rd());
-  std::shuffle(numbers.begin(), numbers.end(), f);
-  return numbers;
+
+// A permutation function for 1 byte.
+inline unsigned char PermuteChar(unsigned char x) {
+  // LCG
+  return x * 113 + 100;
 }
+
+// A permutation function for an int, with a specified maximum.
+// Rather than going all at once and building an LCG for `0..max`,
+// we compose this out of 1-4 calls to PermuteChar, permuting 8 bits at a time.
+inline uint32_t PermuteInt(uint32_t x, uint32_t max) {
+  int num_bytes;
+  if (max <= 1<<8) {
+      num_bytes = 1;
+  } else if (max <= 1 << 16) {
+      num_bytes = 2;
+  } else if (max <= 1 << 24) {
+      num_bytes = 3;
+  } else {
+      num_bytes = 4;
+  }
+
+  unsigned char* begin_inclusive = reinterpret_cast<unsigned char*>(&x);
+  unsigned char* end_inclusive = reinterpret_cast<unsigned char*>(&x + (num_bytes - 1));
+  for (unsigned char* c = begin_inclusive; c <= end_inclusive; ++c) {
+    // Keep running permutations on c until we get an in-range value.
+    // This will only execute more than once for the last byte, and only if max
+    // isn't exactly 1 << (n*8).
+    do {
+        *c = PermuteChar(*c);
+    } while (x >= max);
+  }
+  return x;
+}
+
+template <typename T> class ShuffledSpan {
+ public:
+  ShuffledSpan(const std::vector<T>& arr): begin_(arr.size() != 0 ? &arr[0] : nullptr), size_(arr.size()) {}
+
+  ShuffledSpan(const ShuffledSpan&) = default;
+  ShuffledSpan& operator=(const ShuffledSpan&) = default;
+  ShuffledSpan(ShuffledSpan&&) = default;
+  ShuffledSpan& operator=(ShuffledSpan&&) = default;
+
+  size_t size() const {
+      return size_;
+  }
+
+  const T& operator[](size_t i) const {
+    i = PermuteInt(i, size_);
+    return begin_[i];
+  }
+
+ private:
+  const T* begin_;
+  int32_t size_;
+};
 
 // Determines the maximum latency of reading elements of a vector of size "sz",
 // which is given as input.
@@ -33,20 +78,18 @@ inline std::vector<size_t> ShuffledRange(size_t n) {
 // using MeasureReadLatency(). Later this number can be used to determine cache
 // misses and hits
 inline uint64_t FindMaxReadingTime(size_t buffer_size) {
-  std::vector<size_t> accesses = ShuffledRange(buffer_size);
+  std::vector<char> buffer(buffer_size);
+  ShuffledSpan<char> shuffled(buffer);
 
-  std::vector<char> buffer;
-  buffer.reserve(buffer_size);
-
-  for (size_t i : accesses) {
-    ForceRead(&buffer[i]);
+  for (size_t i = 0; i < shuffled.size(); ++i) {
+    ForceRead(&shuffled[i]);
   }
 
   // Read each element in the same random order and keep track of the slowest
   // read.
   uint64_t max_read_latency = 0;
-  for (size_t i : accesses) {
-    max_read_latency = std::max(max_read_latency, MeasureReadLatency(&buffer[i]));
+  for (size_t i = 0; i < shuffled.size(); ++i) {
+    max_read_latency = std::max(max_read_latency, MeasureReadLatency(&shuffled[i]));
   }
 
   return max_read_latency;
@@ -58,16 +101,14 @@ inline uint64_t FindMaxReadingTime(size_t buffer_size) {
 // measures the time using MeasureReadLatency(). Later this number can be used
 // to determine cache misses and hits
 inline uint64_t FindFirstElementReadingTime(size_t buffer_size) {
-  std::vector<size_t> accesses = ShuffledRange(buffer_size);
+  std::vector<char> buffer(buffer_size);
+  ShuffledSpan<char> shuffled(buffer);
 
-  std::vector<char> buffer;
-  buffer.reserve(buffer_size);
-
-  for (size_t i : accesses) {
-    ForceRead(&buffer[i]);
+  for (size_t i = 0; i < shuffled.size(); ++i) {
+    ForceRead(&shuffled[i]);
   }
 
-  return MeasureReadLatency(&buffer[accesses[0]]);
+  return MeasureReadLatency(&shuffled[0]);
 }
 
 #endif  // EXPERIMENTAL_CACHE_SIZE_H_

--- a/experimental/cache_size_test.cc
+++ b/experimental/cache_size_test.cc
@@ -2,11 +2,12 @@
 #include "cache_size.h"
 
 #include <iostream>
-// Measure how often measuring time is able to accurately determine cache hits
+#include <vector>
+// Measures how often measuring time is able to accurately determine cache hits
 // and cache misses based on the buffer size under analysis and the cache size
 // it checks whether buffer sizes that fit in cache have less reading time or
 // not
-int main(int argc, char* argv[]) {
+int test_timing() {
   static constexpr long kCacheSize = 8 * 1024 * 1024;
   static constexpr long kIterations = 2;
   static constexpr long kTestSizes = 4;
@@ -46,4 +47,38 @@ int main(int argc, char* argv[]) {
   std::cout << res << "% of tests passed." << std::endl;
   if (res > 99) return 0;
   return 1;
+}
+
+
+// Smoke-tests PermuteInt.
+int test_permuting() {
+  int rv;
+  int permuted = PermuteInt(0, /*max=*/1);
+  if ( permuted != 0) {
+    std::cout << "PermuteInt(0, /*max=*/1) = " << permuted << ", expected 0\n";
+    rv = 1;
+  }
+  for (int i = 0; i < 257; ++i) {
+    int permuted = PermuteInt(i, /*max=*/257);
+    if (permuted >= 257) {
+      std::cout << "PermuteInt(" << i << ", /*max=*/257) = " << permuted << ", expected < 257\n";
+      rv = 1;
+    }
+  }
+  return rv;
+}
+
+
+// TODO: absltest... :(
+
+int main() {
+  int rv = 0;
+  if (test_timing()) {
+    std::cout << "test_timing failed";
+    rv = 1;
+  }
+  if (test_permuting()) {
+    std::cout << "test_permuting failed";
+  }
+  return rv;
 }


### PR DESCRIPTION
This should reduce/remove measurement artifacts from the shuffle vector. Since the shuffle vector is, itself, the same size as the buffer being tested for cache, it can lower the measured value by a factor of 2. In fact, it can reduce it by more than 2, because the buffer is of char and the shuffle vector is of int32 or even int64 -- meaning it could cut it by a whole order of magnitude!

Doing some concrete tests on my machine, with the new shuffle we can see a latency increase that really ramps up around 1MB (size of L2 on my laptop):

![new boxplot](https://user-images.githubusercontent.com/356788/102550856-6ed80680-4073-11eb-8737-53a7ccda9d33.png)

But with the old algorithm, it starts *substantially* earlier -- the median stabilizes to a new high value at aroung 100K, a size corresponding to nothing in particular as far as I'm aware:
 
![old boxplot](https://user-images.githubusercontent.com/356788/102550902-857e5d80-4073-11eb-998b-d36900fd53ae.png)
